### PR TITLE
Copyright year fix

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -63,6 +63,7 @@ GEM
 
 PLATFORMS
   arm64-darwin-20
+  ruby
   x86_64-darwin-20
 
 DEPENDENCIES

--- a/_config.yml
+++ b/_config.yml
@@ -83,8 +83,6 @@ nav_sort: case_sensitive # Capital letters sorted before lowercase
 back_to_top: true
 back_to_top_text: "Back to top"
 
-footer_content: "Copyright &copy; 2021. Distributed by an <a href=\"https://github.com/OpenGeoMetadata/opengeometadata.github.io/blob/main/LICENSE\">Apache license.</a>"
-
 # Footer last edited timestamp
 last_edit_timestamp: true # show or hide edit time - page must have `last_modified_date` defined in the frontmatter
 last_edit_time_format: "%b %e %Y at %I:%M %p" # uses ruby's time format: https://ruby-doc.org/stdlib-2.7.0/libdoc/time/rdoc/Time.html

--- a/_includes/footer_custom.html
+++ b/_includes/footer_custom.html
@@ -1,3 +1,1 @@
-{%- if site.footer_content -%}
-  <p class="text-small text-grey-dk-100 mb-0">{{ site.footer_content }}</p>
-{%- endif -%}
+<p class="text-small text-grey-dk-100 mb-0">Copyright &copy; {{ site.time | date: '%Y' }}. Distributed by an <a href=\"https://github.com/OpenGeoMetadata/opengeometadata.github.io/blob/main/LICENSE\">Apache license.</a></p>


### PR DESCRIPTION
Sets the footer copyright year via a variable.

<img width="706" alt="Screen Shot 2022-02-19 at 8 53 37 AM" src="https://user-images.githubusercontent.com/69827/154806211-7c33cec3-f648-4b27-a5bf-993d23965a5b.png">

Fixes #13