### PR TITLE
Revert "Copyright year fix"

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -63,7 +63,6 @@ GEM
 
 PLATFORMS
   arm64-darwin-20
-  ruby
   x86_64-darwin-20
 
 DEPENDENCIES

--- a/_config.yml
+++ b/_config.yml
@@ -83,6 +83,8 @@ nav_sort: case_sensitive # Capital letters sorted before lowercase
 back_to_top: true
 back_to_top_text: "Back to top"
 
+footer_content: "Copyright &copy; 2021. Distributed by an <a href=\"https://github.com/OpenGeoMetadata/opengeometadata.github.io/blob/main/LICENSE\">Apache license.</a>"
+
 # Footer last edited timestamp
 last_edit_timestamp: true # show or hide edit time - page must have `last_modified_date` defined in the frontmatter
 last_edit_time_format: "%b %e %Y at %I:%M %p" # uses ruby's time format: https://ruby-doc.org/stdlib-2.7.0/libdoc/time/rdoc/Time.html

--- a/_includes/footer_custom.html
+++ b/_includes/footer_custom.html
@@ -1,1 +1,3 @@
-<p class="text-small text-grey-dk-100 mb-0">Copyright &copy; {{ site.time | date: '%Y' }}. Distributed by an <a href=\"https://github.com/OpenGeoMetadata/opengeometadata.github.io/blob/main/LICENSE\">Apache license.</a></p>
+{%- if site.footer_content -%}
+  <p class="text-small text-grey-dk-100 mb-0">{{ site.footer_content }}</p>
+{%- endif -%}


### PR DESCRIPTION
Reverts OpenGeoMetadata/opengeometadata.github.io#14

Realized there's an issue with the hyperlink pointing to the Apache license. The code in `_includes/footer_custom.html` now reads: 

```
+<p class="text-small text-grey-dk-100 mb-0">Copyright &copy; {{ site.time | date: '%Y' }}. Distributed by an <a href=\"https://github.com/OpenGeoMetadata/opengeometadata.github.io/blob/main/LICENSE\">Apache license.</a></p>
```

but when deployed the link points to:

```
http://opengeometadata.org/%22https://github.com/OpenGeoMetadata/opengeometadata.github.io/blob/main/LICENSE/%22
```