### PR TITLE
Establish color scheme file

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -96,7 +96,7 @@ gh_edit_branch: "main" # the branch that your docs is served from
 gh_edit_view_mode: "tree" # "tree" or "edit" if you want the user to jump into the editor immediately
 
 # Color scheme currently only supports "dark", "light"/nil (default), or a custom scheme that you define
-color_scheme: nil
+color_scheme: ogm-custom
 
 # Google Analytics Tracking (optional)
 # e.g, UA-1234567-89

--- a/_sass/color_schemes/ogm-custom.scss
+++ b/_sass/color_schemes/ogm-custom.scss
@@ -1,0 +1,2 @@
+$link-color: #2E3292;
+$btn-primary-color: #2E3292;

--- a/index.md
+++ b/index.md
@@ -12,7 +12,7 @@ permalink: /
 A shared repository for geospatial metadata
 {: .fs-6 .fw-300 }
 
-[View our GitHub repositories](https://github.com/OpenGeoMetadata){: .btn .btn-primary .fs-5 .mb-4 .mb-md-0 .mr-2 } [Read our Wiki](https://github.com/OpenGeoMetadata/metadatarepository/wiki){: .btn .fs-5 .mb-4 .mb-md-0 }
+[View our GitHub repositories](https://github.com/OpenGeoMetadata){: .btn .btn-primary .fs-5 .mb-4 .mb-md-0 .mr-2 }
 
 ---
 


### PR DESCRIPTION
This adjusts the color of the links from purple to dark blue to match the logo. Additional customizations can be made to the ogm-custom.scss file.

This also removes the button "Read our Wiki" as we are not using that anymore.

Old
![Screen Shot 2022-02-21 at 10 07 55 AM](https://user-images.githubusercontent.com/2367677/154991165-34fc30a4-b25b-4bd8-a3ad-3fc5d735c9ce.png)

New
![Screen Shot 2022-02-21 at 10 08 24 AM](https://user-images.githubusercontent.com/2367677/154991254-fbe6c06b-4260-4aaa-9f2a-a924d046ed44.png)
