### PR TITLE
Adds upgrade page

### DIFF
--- a/docs/current-schema/index.md
+++ b/docs/current-schema/index.md
@@ -10,12 +10,12 @@ permalink: /docs/current-schema
 # Current Schema
 {: .no_toc }
 
-Details about the new OpenGeoMetadata metadata schema, OGM Aardvark
+Details about the OpenGeoMetadata metadata schema, OGM Aardvark
 {: .fs-6 .fw-300 }
 
-OGM Aardvark is the newest metadata application profile schema for GeoBlacklight. Launched in 2021, it replaces the GeoBlacklight metadata schema version 1.0 ([GBL 1.0](../../legacy-schemas/gbl-1.0)). Aardvark incorporates additional fields for better descriptions of a wider range of resources, as well as syntactical updates in order to improve interoperability between institutions and between schemas.
+OGM Aardvark is a discovery metadata schema for geospatial resources. It was intentionally developed with cross-application in mind and can be used to describe geospatial assets of all kinds. 
 
-OGM Aardvark was intentionally developed with cross-application in mind and can be used to describe geospatial assets of all kinds. For GeoBlacklight users, it is the recommended schema for installations starting with GeoBlacklight version 4.0.
+It is also the newest metadata application profile schema for GeoBlacklight. Launched in 2021, it replaces the GeoBlacklight metadata schema version 1.0 ([GBL 1.0](../../legacy-schemas/gbl-1.0)). Compared to GBL 1.0, Aardvark incorporates additional fields for better descriptions of a wider range of resources, as well as syntactical updates in order to improve interoperability between institutions and between schemas. For GeoBlacklight users, it is the recommended schema for installations starting with GeoBlacklight version 4.0.
 
 ---
 ## Table of contents
@@ -93,13 +93,12 @@ The GeoBlacklight Metadata Schema Workgroup consisted of 16 people from 12 insti
 *   **Solr field type**: This is the suffix appended to the URI and indicates what kind of Solr field should be indexed. For `dct_subject_sm`, the `_sm` stands for String Multiple. It indicates that the field type is a string and that it can have multiple values.
 *   **Value**: This is the information that is entered in a field. It may be free text (literal value) or a URI/code (nonliteral value).
 
-
-## What is different about the new schema?
+## What are the differences between GBL 1.0 and OGM Aardvark?
 
 ### New elements for rights
 {: .no_toc }
 
-One of the highest priorities for the Workgroup was to identify appropriate elements to capture rights information. This information is required at many participating institutions, and was the cause of multiple custom fields at different institutions that served the same purpose.
+One of the highest priorities for the Metadata Workgroup was to identify appropriate elements to capture rights information. This information is required at many participating institutions, and was the cause of multiple custom fields at different institutions that served the same purpose.
 
 After examining how rights are implemented for different projects, notably the Digital Public Library of America (DPLA) and [RightsStatements.org,](https://rightsstatements.org) we recommended three new fields and a renaming of one field. This change is the one instance in which we recommended that an existing GeoBlacklight element with application functionality be replaced by another.
 
@@ -116,7 +115,7 @@ The new set of rights elements are:
 ### New elements for item relations
 {: .no_toc }
 
-One of the thorniest issues we tackled was how to define item relations. We identified four new relationships, redefined two, and added a general, catch-all **Relation** field. The value for each field should be the ID (slug) of the related item.
+The new schema includes seven relationship fields. The value for each field should be the ID (slug) of the related item.
 
 GeoBlacklight version 3.4 and earlier has an Item Relations widget that displays items identified in the **Source** field. Beginning with version 4, this has been updated to use the same widget for each of these fields
 
@@ -149,76 +148,6 @@ The new version always gives preference to elements found in established schemas
 
 The original schema features several descriptive metadata fields that only accept one value. The new schema expands many of these to multiple. This changes the URI suffix from `_s` to` _sm`. Although it will not affect the GeoBlacklight functionality, this practice may conflict with indexing, as Solr will treat `dct_publisher_s` as a different field than `dct_publisher_sm`.
 
-
-## How do I convert my Version 1.0 metadata into Aardvark?
-
-The GeoBlacklight community is working to develop tools within GeoCombine that will systematically convert 1.0 metadata into Aardvark. In the meantime, [this python script](https://github.com/BTAA-Geospatial-Data-Project/GBL-Schema-Update) can be used to batch convert JSON files. The information below can help with crosswalking if these tools aren't sufficient.
-
-### Crosswalkable and new elements
-{: .no_toc }
-
-Most of the elements from GBL Version 1.0 can be crosswalked directly into OGM Aardvark. The values for these elements are the same - only the URI name has changed or the field has been converted to an array.  The following chart shows the mapping from GeoBlacklight version 1.0 into corresponding Aardvark fields.
-
-|  # |       Label       |        GBL 1.0           |      OGM Aardvark      |                Note               |
-|:---|:------------------|:-------------------------|:-----------------------|:----------------------------------|
-| 01 |       Title       | `dc_title_s`             | `dct_title_s`          |           new namespace           |
-| 02 | Alternative Title |                          | `dct_alternative_sm`   |             new field             |
-| 03 |    Description    | `dc_description_s`       | `dct_description_sm`   |new namespace; single to multi-valued|
-| 04 |      Language     | `dc_language_s` or `_sm` | `dct_language_sm`      |new namespace; single to multi-valued|
-| 05 |      Creator      | `dc_creator_sm`          | `dct_creator_sm`       |           new namespace           |
-| 06 |     Publisher     | `dc_publisher_s`         | `dct_publisher_sm`     |new namespace; single to multi-valued|
-| 07 |      Provider     | `dct_provenance_s`       | `schema_provider_s`    |            new URI name           |
-| 08 |   Resource Class  |                          | `gbl_resourceClass_sm` |             new field             |
-| 09 |   Resource Type   |                          | `gbl_resourceType_sm`  |             new field             |
-| 10 |      Subject      | `dc_subject_sm`          | `dct_subject_sm`       |           new namespace           |
-| 11 |       Theme       |                          | `dcat_theme_sm`        |             new field             |
-| 12 |      Keyword      |                          | `dcat_keyword_sm`      |             new field             |
-| 13 | Temporal Coverage | `dct_temporal_sm`        | `dct_temporal_sm`      |             no change             |
-| 14 |    Date Issued    | `dct_issued_s`           | `dct_issued_s`         |             no change             |
-| 15 |     Index Year    | `solr_year_i`            | `gbl_indexYear_im`     |new URI name; single to multi-valued|
-| 16 |     Date Range    |                          | `gbl_dateRange_drsim`  |             new field             |
-| 17 |  Spatial Coverage | `dct_spatial_sm`         | `dct_spatial_sm`       |             no change             |
-| 18 |      Geometry     | `solr_geom`              | `locn_geometry`        |             new field             |
-| 19 |    Bounding Box   | `solr_geom`              | `dcat_bbox`            |             new field             |
-| 20 |      Centroid     |                          | `dcat_centroid`        |             new field             |
-| 21 |      Relation     |                          | `dct_relation_sm`      |             new field             |
-| 22 |     Member Of     |                          | `pcdm_memberOf_sm`     |             new field             |
-| 23 |     Is Part Of    |                          | `dct_isPartOf_sm`      |new value type (see [Elements without a crosswalk](#elements-without-a-crosswalk))|
-| 24 |       Source      | `dc_source_sm`           | `dct_source_sm`        |           new namespace           |
-| 25 |      Version      |                          | `dct_isVersionOf_sm`   |             new field             |
-| 26 |      Replaces     |                          | `dct_replaces_sm`      |             new field             |
-| 27 |   Is Replaced By  |                          | `dct_isReplacedBy_sm`  |             new field             |
-| 28 |       Rights      |                          | `dct_rights_sm`        |             new field             |
-| 29 |   Rights Holder   |                          | `dct_rightsHolder_sm`  |             new field             |
-| 30 |      License      |                          | `dct_license_sm`       |             new field             |
-| 31 |   Access Rights   | `dc_rights_s`            | `dct_accessRights_s`   |            new URI name           |
-| 32 |       Format      | `dc_format_s`            | `dct_format_s`         |           new namespace           |
-| 33 |     File Size     |                          | `gbl_fileSize_s`       |             new field             |
-| 34 |   WxS Identifier  | `layer_id_s`             | `gbl_wxsIdentifier_s`  |            new URI name           |
-| 35 |     References    | `dct_references_s`       | `dct_references_s`     |             no change             |
-| 36 |         ID        | `layer_slug_s`           | `id`                   |            new URI name           |
-| 37 |     Identifier    | `dc_identifier_s`        | `dct_identifier_sm`    |new namespace; single to multi-valued |
-| 38 |      Modified     | `layer_modified_dt`      | `gbl_mdModified_dt`    |            new URI name           |
-| 39 |  Metadata Version | `geoblacklight_version`  | `gbl_mdVersion_s`      |            new URI name           |
-| 40 |     Suppressed    | `suppressed_b`           | `gbl_suppressed_b`     |           new namespace           |
-| 41 |   Georeferenced   |                          | `gbl_georeferenced_b`  |             new field             |
-
-### Elements without a crosswalk
-{: .no_toc }
-
-There are three elements in GBL 1.0 that do not directly translate into OGM Aardvark. While they have been replaced with similar fields in OGM Aardvark, the **values themselves** would need to be altered during crosswalking.
-
-**Type (dc_type_s)**
-* GBL 1.0 Description: This single-valued GBL 1.0 field observes the Dublin Core controlled vocabulary for Type, including Dataset, Image, Collection, Interactive Resource, or Physical Object.
-* Similar Aardvark element: This has been replaced in Aardvark with the multi-valued [Resource Class](../aardvarkSchema/resource-class/), which uses a custom controlled vocabulary of Collections, Datasets, Imagery, Maps, Web Services, and/or Other.
-
-**Geometry Type (layer_geom_type_s)**
-* GBL 1.0 Description: This single-valued GBL 1.0 field differentiates between vector (Point, Line, Polygon), raster (Raster, Image), non-spatial formats (Table), or a combination (Mixed).
-* Similar Aardvark element: This has been replaced in Aardvark with the multi-valued [Resource Type](../aardvarkSchema/resource-type/), which uses a controlled vocabulary drawn from Library of Congress cartographic genres and GIS geometries.
-
-**Is Part Of (dct_isPartOf_sm)**
-* GBL 1.0 Description: This multi-valued GBL 1.0 plain text field is for writing out the name of a collection. Example: `dct_isPartOf_sm:"Village Maps of India"`
-* Similar Aardvark element: The URI is the same in Aardvark, but it is now a non-literal field. The value must be one or more IDs that reference another record within the system. Example: `dct_isPartOf_sm:"princeton-z603r079s"`
 
 ## Will Aardvark work with my GeoBlacklight installation?
 

--- a/docs/current-schema/ogm-aardvark/resource-class.md
+++ b/docs/current-schema/ogm-aardvark/resource-class.md
@@ -31,6 +31,6 @@ nav_order: 8
 | Datasets     |
 | Imagery      |
 | Maps         |
-| Web Services |
+| Web services |
 | Websites     |
 | Other        |

--- a/docs/current-schema/upgrading.md
+++ b/docs/current-schema/upgrading.md
@@ -1,0 +1,102 @@
+---
+layout: default
+title: Upgrading
+nav_order: 3
+has_toc: true
+parent: Current Schema
+
+---
+
+# Upgrading Metadata from GBL 1.0 to OGM Aardvark
+{: .no_toc }
+
+---
+## Table of contents
+{: .no_toc .text-delta }
+
+1. TOC
+{:toc}
+
+---
+
+## Full Crosswalk Table
+
+
+Most of the elements from GBL 1.0 can be crosswalked directly into OGM Aardvark. The values for these elements are the same - only the URI name has changed or the field has been converted to an array.  
+
+The following chart shows the full Aardvark schema and which GBL 1.0 fields can be directly mapped.
+
+|  # |       Label       |        GBL 1.0           |      OGM Aardvark      |                Note               |
+|:---|:------------------|:-------------------------|:-----------------------|:----------------------------------|
+| 01 |       Title       | `dc_title_s`             | `dct_title_s`          |           new namespace           |
+| 02 | Alternative Title |                          | `dct_alternative_sm`   |             new field             |
+| 03 |    Description    | `dc_description_s`       | `dct_description_sm`   |new namespace; single to multi-valued|
+| 04 |      Language     | `dc_language_s` or `_sm` | `dct_language_sm`      |new namespace; single to multi-valued|
+| 05 |      Creator      | `dc_creator_sm`          | `dct_creator_sm`       |           new namespace           |
+| 06 |     Publisher     | `dc_publisher_s`         | `dct_publisher_sm`     |new namespace; single to multi-valued|
+| 07 |      Provider     | `dct_provenance_s`       | `schema_provider_s`    |            new URI name           |
+| 08 |   Resource Class  |                          | `gbl_resourceClass_sm` |             new field             |
+| 09 |   Resource Type   |                          | `gbl_resourceType_sm`  |             new field             |
+| 10 |      Subject      | `dc_subject_sm`          | `dct_subject_sm`       |           new namespace           |
+| 11 |       Theme       |                          | `dcat_theme_sm`        |             new field             |
+| 12 |      Keyword      |                          | `dcat_keyword_sm`      |             new field             |
+| 13 | Temporal Coverage | `dct_temporal_sm`        | `dct_temporal_sm`      |             no change             |
+| 14 |    Date Issued    | `dct_issued_s`           | `dct_issued_s`         |             no change             |
+| 15 |     Index Year    | `solr_year_i`            | `gbl_indexYear_im`     |new URI name; single to multi-valued|
+| 16 |     Date Range    |                          | `gbl_dateRange_drsim`  |             new field             |
+| 17 |  Spatial Coverage | `dct_spatial_sm`         | `dct_spatial_sm`       |             no change             |
+| 18 |      Geometry     | `solr_geom`              | `locn_geometry`        |             new field             |
+| 19 |    Bounding Box   | `solr_geom`              | `dcat_bbox`            |             new field             |
+| 20 |      Centroid     |                          | `dcat_centroid`        |             new field             |
+| 21 |      Relation     |                          | `dct_relation_sm`      |             new field             |
+| 22 |     Member Of     |                          | `pcdm_memberOf_sm`     |             new field             |
+| 23 |     Is Part Of    |                          | `dct_isPartOf_sm`      |new value type (see [Elements without a crosswalk](#elements-without-a-crosswalk))|
+| 24 |       Source      | `dc_source_sm`           | `dct_source_sm`        |           new namespace           |
+| 25 |      Version      |                          | `dct_isVersionOf_sm`   |             new field             |
+| 26 |      Replaces     |                          | `dct_replaces_sm`      |             new field             |
+| 27 |   Is Replaced By  |                          | `dct_isReplacedBy_sm`  |             new field             |
+| 28 |       Rights      |                          | `dct_rights_sm`        |             new field             |
+| 29 |   Rights Holder   |                          | `dct_rightsHolder_sm`  |             new field             |
+| 30 |      License      |                          | `dct_license_sm`       |             new field             |
+| 31 |   Access Rights   | `dc_rights_s`            | `dct_accessRights_s`   |            new URI name           |
+| 32 |       Format      | `dc_format_s`            | `dct_format_s`         |           new namespace           |
+| 33 |     File Size     |                          | `gbl_fileSize_s`       |             new field             |
+| 34 |   WxS Identifier  | `layer_id_s`             | `gbl_wxsIdentifier_s`  |            new URI name           |
+| 35 |     References    | `dct_references_s`       | `dct_references_s`     |             no change             |
+| 36 |         ID        | `layer_slug_s`           | `id`                   |            new URI name           |
+| 37 |     Identifier    | `dc_identifier_s`        | `dct_identifier_sm`    |new namespace; single to multi-valued |
+| 38 |      Modified     | `layer_modified_dt`      | `gbl_mdModified_dt`    |            new URI name           |
+| 39 |  Metadata Version | `geoblacklight_version`  | `gbl_mdVersion_s`      |            new URI name           |
+| 40 |     Suppressed    | `suppressed_b`           | `gbl_suppressed_b`     |           new namespace           |
+| 41 |   Georeferenced   |                          | `gbl_georeferenced_b`  |             new field             |
+
+## Elements without a crosswalk
+
+
+There are three elements in GBL 1.0 that do not directly translate into OGM Aardvark. While they have been replaced with similar fields in OGM Aardvark, the **values themselves** would need to be altered during crosswalking.
+
+**Type (dc_type_s)**
+* GBL 1.0 Description: This single-valued GBL 1.0 field observes the Dublin Core controlled vocabulary for Type, including Dataset, Image, Collection, Interactive Resource, or Physical Object.
+* Similar Aardvark element: This has been replaced in Aardvark with the multi-valued [Resource Class](../aardvarkSchema/resource-class/), which uses a custom controlled vocabulary of Collections, Datasets, Imagery, Maps, Web services, and/or Other.
+
+**Geometry Type (layer_geom_type_s)**
+* GBL 1.0 Description: This single-valued GBL 1.0 field differentiates between vector (Point, Line, Polygon), raster (Raster, Image), non-spatial formats (Table), or a combination (Mixed).
+* Similar Aardvark element: This has been replaced in Aardvark with the multi-valued [Resource Type](../aardvarkSchema/resource-type/), which uses a controlled vocabulary drawn from Library of Congress cartographic genres and GIS geometries.
+
+**Is Part Of (dct_isPartOf_sm)**
+* GBL 1.0 Description: This multi-valued GBL 1.0 plain text field is for writing out the name of a collection. Example: `dct_isPartOf_sm:"Village Maps of India"`
+* Similar Aardvark element: The URI is the same in Aardvark, but it is now a non-literal field. The value must be one or more IDs that reference another record within the system. Example: `dct_isPartOf_sm:"princeton-z603r079s"`
+
+## Tools and techniques for upgrading
+
+### XSLTs for ISO and FGDC
+New XSLTs to transform from ISO 19139 or FGDC to OGM Aardvark will be available here: [https://github.com/OpenGeoMetadata/GeoCombine/tree/main/lib/xslt](https://github.com/OpenGeoMetadata/GeoCombine/tree/main/lib/xslt)
+
+### Programmatic conversion of JSON files
+This basic [Python script](https://github.com/BTAA-Geospatial-Data-Project/GBL-Schema-Update) can batch convert GBL 1.0 json files to OGM Aardvark. However, note the three elements listed above that do not have direct crosswalks.
+
+### Spreadsheet manipulation
+This technique combines automatic conversions and manual edits:
+1. Convert your GBL 1.0 metadata files to a CSV.
+2. Manually augment and adjust values using spreadsheet functions.
+3. Convert your spreadsheet to OGM Aardvark JSONs.

--- a/docs/helpful-resources/ogm-metadata-basics/fields.md
+++ b/docs/helpful-resources/ogm-metadata-basics/fields.md
@@ -83,13 +83,3 @@ If an organization wishes to implement a custom metadata field for their GeoBlac
 Examples:
 * `b1g_code_s` - Internal code that organizes items by their source collection
 * `nyu_addl_dspace_s` - A 5 digit number that is the "internal identifier" for DSpace, the repository software that mints handles for all NYU's items. The internal id must be paired with the handle in order to post metadata and data via the system API.
-
-## Deprecated Fields
-
-Fields are occasionally deprecated during revisions of the schemas. See the [GBL 1.0 --> OGM Aardvark](../about-ogm-aardvark/#crosswalkable-and-new-elements) crosswalk table for a complete list of deprecated field names from the most recent update. In addition, these previous deprecated fields may occur in older metadata records:
-
-* `uuid`
-* `dc_relation_sm`
-* `georss_box_s`
-* `georss_point_s`
-* `georss_polygon_s`

--- a/docs/legacy-versions/gbl-0.5.md
+++ b/docs/legacy-versions/gbl-0.5.md
@@ -1,0 +1,22 @@
+---
+layout: default
+title: GBL 0.5
+parent: Legacy Versions
+nav_order: 3
+---
+
+# GBL 0.5
+
+GeoBlacklight metadata schema version 0.5
+{: .fs-6 .fw-300 }
+
+This is a legacy format. The GeoBlacklight Community recommends using [OGM Aardvark](../../current-schema/ogm-aardvark) for GeoBlacklight versions 4.0 and higher.
+
+---
+The earliest metadata schema for GeoBlacklight included these now deprecated fields:
+
+* `uuid`
+* `dc_relation_sm`
+* `georss_box_s`
+* `georss_point_s`
+* `georss_polygon_s`


### PR DESCRIPTION
This adds an "Upgrading" page, which involved moving the crosswalk from the current schema page. I also created a new page for the first legacy metadata schema and moved the info about the deprecated fields there.

This could be improved, but is a start.