### PR TITLE
Update "publishing in Solr" page

### DIFF
--- a/docs/helpful-resources/publishing-in-solr.md
+++ b/docs/helpful-resources/publishing-in-solr.md
@@ -8,23 +8,19 @@ nav_order: 4
 # Publishing Metadata in Solr
 {: .no_toc }
 
-subtitle
+How to publish metadata records in Solr for GeoBlacklight integration
 {: .fs-6 .fw-300 }
 
 ---
-## Table of contents
-{: .no_toc .text-delta }
 
-1. TOC
-{:toc}
+## Adding Metadata Records to Solr
 
----
+Metadata for GeoBlacklight instances is stored and indexed in Solr. The Solr application identifies each metadata record as a “document.” The process of adding documents to Solr is called “indexing.” 
 
-## Publishing Metadata in Solr
+**Option A: Manually indexing**
 
-Metadata for GeoBlacklight instances is stored and indexed in Solr.
+If you have access to your Solr Dashboard panel, you can add records manually by pasting them into the Documents pane.
 
-### Adding Metadata Records to Solr
-{: .no_toc }
+**Option B: Indexing via scripts**
 
-The Solr application identifies each metadata record as a “document.” The process of adding documents to Solr is called “indexing.” If you have access to your Solr Dashboard panel, you can add records manually by pasting them into the Documents pane. However, it is more practical to use a process for batch adding, updating, and deleting the records. Most of the available processes are in the form of command-line scripts. See the Tools and Resources page for examples.
+It is often more practical to use a process for batch adding, updating, and deleting the records. Most of the available processes are in the form of command-line scripts. See [Scripts and Tools](../../helpful-resources/scripts-and-tools) for examples.


### PR DESCRIPTION
This PR migrates content from the [Publishing metadata in Solr](https://github.com/geoblacklight/geoblacklight/wiki/Publishing-metadata-in-Solr) wiki page to the new OGM site. Most of this content was already migrated to other parts of the OGM site (specifically, the [Overview](https://opengeometadata.org/docs/helpful-resources/ogm-metadata-basics/overview/#unique-keys) and [Fields](https://opengeometadata.org/docs/helpful-resources/ogm-metadata-basics/fields/#field-elements) sections). There isn't much left just for this page. 

In the future it could be really helpful to add screenshots of the different workflows. To a total newbie, this was a big black box for me!

<img width="969" alt="Screen Shot 2022-02-25 at 11 13 03 AM" src="https://user-images.githubusercontent.com/36506059/155749321-83cc87bc-1a78-4473-8b5b-fa1c4d163106.png">

