### PR TITLE
Moves section on viewing metadata

### DIFF
--- a/docs/helpful-resources/publishing-in-solr.md
+++ b/docs/helpful-resources/publishing-in-solr.md
@@ -5,14 +5,12 @@ parent: Helpful Resources
 nav_order: 4
 ---
 
-
 # Publishing Metadata in Solr
 {: .no_toc }
 
 How to publish metadata records in Solr for GeoBlacklight integration
 {: .fs-6 .fw-300 }
 
----
 ---
 ## Table of contents
 {: .no_toc .text-delta }
@@ -22,9 +20,9 @@ How to publish metadata records in Solr for GeoBlacklight integration
 
 ---
 
-## Adding Metadata Records to Solr
+## Add metadata records to Solr
 
-Metadata for GeoBlacklight instances is stored and indexed in Solr. The Solr application identifies each metadata record as a “document.” The process of adding documents to Solr is called “indexing.” 
+Metadata for GeoBlacklight instances is stored and indexed in Solr. The Solr application identifies each metadata record as a “document.” The process of adding documents to Solr is called “indexing.”
 
 **Option A: Manually indexing**
 
@@ -34,14 +32,15 @@ If you have access to your Solr Dashboard panel, you can add records manually by
 
 It is often more practical to use a process for batch adding, updating, and deleting the records. Most of the available processes are in the form of command-line scripts. See [Scripts and Tools](../../helpful-resources/scripts-and-tools) for examples.
 
-## Viewing Solr Metadata within GeoBlacklight
+## View Solr metadata within GeoBlacklight
 
 The raw metadata files can be viewed by appending terms to the end of an item's show page URL.
 
 ### .xml
 {: .no_toc }
 
-* produces a Dublin Core XML document in the [OAI_DC schema](https://www.openarchives.org/OAI/2.0/oai_dc.xsd). The fields for this document can be adjusted in the `solr_document.rb`, which is found here: `app/models/solr_document.rb`. Example: https://geo.btaa.org/catalog/145055E1-87EF-4D13-B138-4DC3907F3677.xml.
+* Produces a Dublin Core XML document in the [OAI_DC schema](https://www.openarchives.org/OAI/2.0/oai_dc.xsd). The fields for this document can be adjusted in the `solr_document.rb`, which is found here: `app/models/solr_document.rb`.
+* Example: [https://geo.btaa.org/catalog/145055E1-87EF-4D13-B138-4DC3907F3677.xml](https://geo.btaa.org/catalog/145055E1-87EF-4D13-B138-4DC3907F3677.xml)
 
 ### .json
 {: .no_toc }

--- a/docs/helpful-resources/publishing-in-solr.md
+++ b/docs/helpful-resources/publishing-in-solr.md
@@ -5,11 +5,20 @@ parent: Helpful Resources
 nav_order: 4
 ---
 
+
 # Publishing Metadata in Solr
 {: .no_toc }
 
 How to publish metadata records in Solr for GeoBlacklight integration
 {: .fs-6 .fw-300 }
+
+---
+---
+## Table of contents
+{: .no_toc .text-delta }
+
+1. TOC
+{:toc}
 
 ---
 
@@ -24,3 +33,24 @@ If you have access to your Solr Dashboard panel, you can add records manually by
 **Option B: Indexing via scripts**
 
 It is often more practical to use a process for batch adding, updating, and deleting the records. Most of the available processes are in the form of command-line scripts. See [Scripts and Tools](../../helpful-resources/scripts-and-tools) for examples.
+
+## Viewing Solr Metadata within GeoBlacklight
+
+The raw metadata files can be viewed by appending terms to the end of an item's show page URL.
+
+### .xml
+{: .no_toc }
+
+* produces a Dublin Core XML document in the [OAI_DC schema](https://www.openarchives.org/OAI/2.0/oai_dc.xsd). The fields for this document can be adjusted in the `solr_document.rb`, which is found here: `app/models/solr_document.rb`. Example: https://geo.btaa.org/catalog/145055E1-87EF-4D13-B138-4DC3907F3677.xml.
+
+### .json
+{: .no_toc }
+
+* GeoBlacklight until version 1.9: produces a full metadata file for the item as a flat JSON document.
+* GeoBlacklight 2.0+: produces a nested JSON document of the metadata that appears on the item page. This document can be harvested by the [JSON:API](https://jsonapi.org/) protocol.
+
+### /raw
+{: .no_toc }
+
+* GeoBlacklight until version 1.9: not available.
+* GeoBlacklight 2.0+: displays the full metadata file for the item as a flat JSON document.

--- a/docs/helpful-resources/writing-metadata.md
+++ b/docs/helpful-resources/writing-metadata.md
@@ -89,29 +89,3 @@ Once the metadata records are in the OpenGeoMetadata format, they should be vali
 {: .no_toc }
 
 Use [GeoCombine](https://github.com/OpenGeoMetadata/GeoCombine), which has a [.valid? method](http://www.rubydoc.info/gems/geo_combine/0.1.0/GeoCombine/Geoblacklight#valid%3F-instance_method) that makes using these tools simple.
-
-## Display the metadata in GeoBlacklight
-
-This section refers to documentation created for GeoBlacklight version 2.0. The code may look different if you are running a newer version of the software.
-{: .note}
-
-The metadata that appears on an item's show page is set by a file called `catalog_controller.rb`. This file is located in the application at `app/controllers/catalog_controller.rb`. For more information on how to customize the show page, see [this section of the GeoBlacklight tutorial](https://geoblacklight.org/tutorial/2015/02/09/customize-your-application.html#customize-metadata-shown).
-
-Other metadata views can be found by appending terms to the end of an item's show page URL. Note that there are some differences in these features between GeoBlacklight 2.0 and earlier versions. See [this section of the upgrade guide to GeoBlacklight version 2.0](https://github.com/geoblacklight/geoblacklight/wiki/GeoBlacklight-2.0-Upgrade-Guide#update-catalogcontroller) to enable all of these features. The following methods involve adding an extension to the show page URL:
-
-### .xml
-{: .no_toc }
-
-* produces a Dublin Core XML document in the [OAI_DC schema](https://www.openarchives.org/OAI/2.0/oai_dc.xsd). The fields for this document can be adjusted in the `solr_document.rb`, which is found here: `app/models/solr_document.rb`. Example: https://geo.btaa.org/catalog/145055E1-87EF-4D13-B138-4DC3907F3677.xml.
-
-### .json
-{: .no_toc }
-
-* GeoBlacklight until version 1.9: produces a full metadata file for the item as a flat JSON document.
-* GeoBlacklight 2.0+: produces a nested JSON document of the metadata that appears on the item page. This document can be harvested by the [JSON:API](https://jsonapi.org/) protocol.
-
-### /raw
-{: .no_toc }
-
-* GeoBlacklight until version 1.9: not available.
-* GeoBlacklight 2.0+: displays the full metadata file for the item as a flat JSON document.


### PR DESCRIPTION
This moves a section from the end of Writing Metadata to the Publishing in Solr page.

<img width="728" alt="Screen Shot 2022-02-25 at 10 56 03 AM" src="https://user-images.githubusercontent.com/2367677/155755578-d6190bdf-23ce-4f80-be7c-d04c63cbed57.png">
