### PR TITLE
Restructure current schema

### DIFF
--- a/docs/about-aardvark.md
+++ b/docs/about-aardvark.md
@@ -1,11 +1,12 @@
 ---
 layout: default
-title: Current Schema
-nav_order: 3
-has_children: true
+title: About Aardvark
+has_children: false
+nav_exclude: true
+
 ---
 
-# Current Schema
+# About Aardvark
 {: .no_toc }
 
 Details about the OpenGeoMetadata metadata schema, OGM Aardvark

--- a/docs/about-aardvark.md
+++ b/docs/about-aardvark.md
@@ -6,7 +6,7 @@ nav_exclude: true
 
 ---
 
-# About Aardvark
+# About OGM Aardvark
 {: .no_toc }
 
 Details about the OpenGeoMetadata metadata schema, OGM Aardvark

--- a/docs/about-ogm-aardvark.md
+++ b/docs/about-ogm-aardvark.md
@@ -1,6 +1,6 @@
 ---
 layout: default
-title: About Aardvark
+title: About OGM Aardvark
 has_children: false
 nav_exclude: true
 

--- a/docs/further-reading.md
+++ b/docs/further-reading.md
@@ -2,7 +2,7 @@
 layout: default
 title: Further Reading
 parent: Helpful Resources
-nav_order: 4
+nav_order: 5
 ---
 
 # Further Reading

--- a/docs/ogm-aardvark.md
+++ b/docs/ogm-aardvark.md
@@ -11,7 +11,7 @@ has_toc: false
 OpenGeoMetadata Aardvark metadata schema (2021)
 {: .fs-6 .fw-300 }
 
-[About OGM Aardvark](about-aardvark){: .btn .btn-primary .fs-5 .mb-4 .mb-md-0 .mr-2 }
+[About OGM Aardvark](about-ogm-aardvark){: .btn .btn-primary .fs-5 .mb-4 .mb-md-0 .mr-2 }
 [How to Upgrade from GBL 1.0](upgrading){: .btn .btn-primary .fs-5 .mb-4 .mb-md-0 .mr-2 }
 
 

--- a/docs/ogm-aardvark.md
+++ b/docs/ogm-aardvark.md
@@ -11,7 +11,7 @@ has_toc: false
 OpenGeoMetadata Aardvark metadata schema (2021)
 {: .fs-6 .fw-300 }
 
-[About Aardvark](about-aardvark){: .btn .btn-primary .fs-5 .mb-4 .mb-md-0 .mr-2 }
+[About OGM Aardvark](about-aardvark){: .btn .btn-primary .fs-5 .mb-4 .mb-md-0 .mr-2 }
 [How to Upgrade from GBL 1.0](upgrading){: .btn .btn-primary .fs-5 .mb-4 .mb-md-0 .mr-2 }
 
 

--- a/docs/ogm-aardvark.md
+++ b/docs/ogm-aardvark.md
@@ -1,8 +1,7 @@
 ---
 layout: default
 title: OGM Aardvark
-parent: Current Schema
-nav_order: 1
+nav_order: 3
 has_children: true
 has_toc: false
 ---
@@ -11,6 +10,9 @@ has_toc: false
 
 OpenGeoMetadata Aardvark metadata schema (2021)
 {: .fs-6 .fw-300 }
+
+[About Aardvark](about-aardvark){: .btn .btn-primary .fs-5 .mb-4 .mb-md-0 .mr-2 }
+[How to Upgrade from GBL 1.0](upgrading){: .btn .btn-primary .fs-5 .mb-4 .mb-md-0 .mr-2 }
 
 
 ## List of Fields

--- a/docs/ogm-aardvark/access-rights.md
+++ b/docs/ogm-aardvark/access-rights.md
@@ -2,7 +2,6 @@
 layout: default
 title: Access Rights
 parent: OGM Aardvark
-grand_parent: Current Schema
 nav_order: 31
 ---
 

--- a/docs/ogm-aardvark/alternative-title.md
+++ b/docs/ogm-aardvark/alternative-title.md
@@ -2,7 +2,6 @@
 layout: default
 title: Alternative Title
 parent: OGM Aardvark
-grand_parent: Current Schema
 nav_order: 2
 ---
 

--- a/docs/ogm-aardvark/bounding-box.md
+++ b/docs/ogm-aardvark/bounding-box.md
@@ -2,7 +2,6 @@
 layout: default
 title: Bounding Box
 parent: OGM Aardvark
-grand_parent: Current Schema
 nav_order: 19
 ---
 

--- a/docs/ogm-aardvark/centroid.md
+++ b/docs/ogm-aardvark/centroid.md
@@ -2,7 +2,6 @@
 layout: default
 title: Centroid
 parent: OGM Aardvark
-grand_parent: Current Schema
 nav_order: 20
 ---
 

--- a/docs/ogm-aardvark/creator.md
+++ b/docs/ogm-aardvark/creator.md
@@ -2,7 +2,6 @@
 layout: default
 title: Creator
 parent: OGM Aardvark
-grand_parent: Current Schema
 nav_order: 5
 ---
 

--- a/docs/ogm-aardvark/date-issued.md
+++ b/docs/ogm-aardvark/date-issued.md
@@ -2,7 +2,6 @@
 layout: default
 title: Date Issued
 parent: OGM Aardvark
-grand_parent: Current Schema
 nav_order: 14
 ---
 

--- a/docs/ogm-aardvark/date-range.md
+++ b/docs/ogm-aardvark/date-range.md
@@ -2,7 +2,6 @@
 layout: default
 title: Date Range
 parent: OGM Aardvark
-grand_parent: Current Schema
 nav_order: 16
 ---
 

--- a/docs/ogm-aardvark/description.md
+++ b/docs/ogm-aardvark/description.md
@@ -2,7 +2,6 @@
 layout: default
 title: Description
 parent: OGM Aardvark
-grand_parent: Current Schema
 nav_order: 3
 ---
 

--- a/docs/ogm-aardvark/file-size.md
+++ b/docs/ogm-aardvark/file-size.md
@@ -2,7 +2,6 @@
 layout: default
 title: File Size
 parent: OGM Aardvark
-grand_parent: Current Schema
 nav_order: 33
 ---
 

--- a/docs/ogm-aardvark/format.md
+++ b/docs/ogm-aardvark/format.md
@@ -2,7 +2,6 @@
 layout: default
 title: Format
 parent: OGM Aardvark
-grand_parent: Current Schema
 nav_order: 32
 ---
 

--- a/docs/ogm-aardvark/geometry.md
+++ b/docs/ogm-aardvark/geometry.md
@@ -2,7 +2,6 @@
 layout: default
 title: Geometry
 parent: OGM Aardvark
-grand_parent: Current Schema
 nav_order: 18
 ---
 

--- a/docs/ogm-aardvark/georeferenced.md
+++ b/docs/ogm-aardvark/georeferenced.md
@@ -2,7 +2,6 @@
 layout: default
 title: Georeferenced
 parent: OGM Aardvark
-grand_parent: Current Schema
 nav_order: 41
 ---
 

--- a/docs/ogm-aardvark/id.md
+++ b/docs/ogm-aardvark/id.md
@@ -2,7 +2,6 @@
 layout: default
 title: ID
 parent: OGM Aardvark
-grand_parent: Current Schema
 nav_order: 36
 ---
 

--- a/docs/ogm-aardvark/identifier.md
+++ b/docs/ogm-aardvark/identifier.md
@@ -2,7 +2,6 @@
 layout: default
 title: Identifier
 parent: OGM Aardvark
-grand_parent: Current Schema
 nav_order: 37
 ---
 

--- a/docs/ogm-aardvark/index-year.md
+++ b/docs/ogm-aardvark/index-year.md
@@ -2,7 +2,6 @@
 layout: default
 title: Index Year
 parent: OGM Aardvark
-grand_parent: Current Schema
 nav_order: 15
 ---
 

--- a/docs/ogm-aardvark/is-part-of.md
+++ b/docs/ogm-aardvark/is-part-of.md
@@ -1,10 +1,7 @@
 ---
 layout: default
 title: Is Part Of
-
 parent: OGM Aardvark
-grand_parent: Current Schema
-
 nav_order: 23
 ---
 

--- a/docs/ogm-aardvark/is-replaced-by.md
+++ b/docs/ogm-aardvark/is-replaced-by.md
@@ -1,10 +1,7 @@
 ---
 layout: default
 title: Is Replaced By
-
 parent: OGM Aardvark
-grand_parent: Current Schema
-
 nav_order: 27
 ---
 

--- a/docs/ogm-aardvark/is-version-of.md
+++ b/docs/ogm-aardvark/is-version-of.md
@@ -1,10 +1,7 @@
 ---
 layout: default
 title: Is Version Of
-
 parent: OGM Aardvark
-grand_parent: Current Schema
-
 nav_order: 25
 ---
 

--- a/docs/ogm-aardvark/keyword.md
+++ b/docs/ogm-aardvark/keyword.md
@@ -2,7 +2,6 @@
 layout: default
 title: Keyword
 parent: OGM Aardvark
-grand_parent: Current Schema
 nav_order: 12
 ---
 

--- a/docs/ogm-aardvark/language.md
+++ b/docs/ogm-aardvark/language.md
@@ -2,7 +2,6 @@
 layout: default
 title: Language
 parent: OGM Aardvark
-grand_parent: Current Schema
 nav_order: 4
 ---
 

--- a/docs/ogm-aardvark/license.md
+++ b/docs/ogm-aardvark/license.md
@@ -1,10 +1,7 @@
 ---
 layout: default
 title: License
-
 parent: OGM Aardvark
-grand_parent: Current Schema
-
 nav_order: 30
 ---
 

--- a/docs/ogm-aardvark/member-of.md
+++ b/docs/ogm-aardvark/member-of.md
@@ -1,10 +1,7 @@
 ---
 layout: default
 title: Member Of
-
 parent: OGM Aardvark
-grand_parent: Current Schema
-
 nav_order: 22
 ---
 

--- a/docs/ogm-aardvark/metadata-version.md
+++ b/docs/ogm-aardvark/metadata-version.md
@@ -1,10 +1,7 @@
 ---
 layout: default
 title: Metadata Version
-
 parent: OGM Aardvark
-grand_parent: Current Schema
-
 nav_order: 39
 ---
 

--- a/docs/ogm-aardvark/modified.md
+++ b/docs/ogm-aardvark/modified.md
@@ -1,10 +1,7 @@
 ---
 layout: default
 title: Modified
-
 parent: OGM Aardvark
-grand_parent: Current Schema
-
 nav_order: 38
 ---
 

--- a/docs/ogm-aardvark/provider.md
+++ b/docs/ogm-aardvark/provider.md
@@ -2,7 +2,6 @@
 layout: default
 title: Provider
 parent: OGM Aardvark
-grand_parent: Current Schema
 nav_order: 7
 ---
 

--- a/docs/ogm-aardvark/publisher.md
+++ b/docs/ogm-aardvark/publisher.md
@@ -2,7 +2,6 @@
 layout: default
 title: Publisher
 parent: OGM Aardvark
-grand_parent: Current Schema
 nav_order: 6
 ---
 

--- a/docs/ogm-aardvark/references.md
+++ b/docs/ogm-aardvark/references.md
@@ -1,10 +1,7 @@
 ---
 layout: default
 title: References
-
 parent: OGM Aardvark
-grand_parent: Current Schema
-
 nav_order: 35
 ---
 

--- a/docs/ogm-aardvark/relation.md
+++ b/docs/ogm-aardvark/relation.md
@@ -1,10 +1,7 @@
 ---
 layout: default
 title: Relation
-
 parent: OGM Aardvark
-grand_parent: Current Schema
-
 nav_order: 21
 ---
 

--- a/docs/ogm-aardvark/replaces.md
+++ b/docs/ogm-aardvark/replaces.md
@@ -1,10 +1,7 @@
 ---
 layout: default
 title: Replaces
-
 parent: OGM Aardvark
-grand_parent: Current Schema
-
 nav_order: 26
 ---
 

--- a/docs/ogm-aardvark/resource-class.md
+++ b/docs/ogm-aardvark/resource-class.md
@@ -2,7 +2,6 @@
 layout: default
 title: Resource Class
 parent: OGM Aardvark
-grand_parent: Current Schema
 nav_order: 8
 ---
 

--- a/docs/ogm-aardvark/resource-type.md
+++ b/docs/ogm-aardvark/resource-type.md
@@ -2,7 +2,6 @@
 layout: default
 title: Resource Type
 parent: OGM Aardvark
-grand_parent: Current Schema
 nav_order: 9
 ---
 

--- a/docs/ogm-aardvark/resource-type.md
+++ b/docs/ogm-aardvark/resource-type.md
@@ -30,10 +30,12 @@ nav_order: 9
 | Aerial photographs                                         | LOC    |
 | Aerial views                                               | LOC    |
 | Aeronautical charts                                        | LOC    |
+| Annotations                                                | GBL    |
 | Armillary spheres                                          | LOC    |
 | Astronautical charts                                       | LOC    |
 | Astronomical models                                        | LOC    |
 | Atlases                                                    | LOC    |
+| Basemaps                                                   | GBL    |
 | Bathymetric maps                                           | LOC    |
 | Block diagrams                                             | LOC    |
 | Bottle-charts                                              | LOC    |
@@ -94,6 +96,7 @@ nav_order: 9
 | Satellite imagery                                          | GBL    |
 | Statistical maps                                           | LOC    |
 | Stick charts                                               | LOC    |
+| Streetview photographs                                     | GBL    |
 | Strip maps                                                 | LOC    |
 | Table data                                                 | GBL    |
 | Thematic maps                                              | LOC    |

--- a/docs/ogm-aardvark/rights-holder.md
+++ b/docs/ogm-aardvark/rights-holder.md
@@ -1,10 +1,7 @@
 ---
 layout: default
 title: Rights Holder
-
 parent: OGM Aardvark
-grand_parent: Current Schema
-
 nav_order: 29
 ---
 

--- a/docs/ogm-aardvark/rights.md
+++ b/docs/ogm-aardvark/rights.md
@@ -1,10 +1,7 @@
 ---
 layout: default
 title: Rights
-
 parent: OGM Aardvark
-grand_parent: Current Schema
-
 nav_order: 28
 ---
 

--- a/docs/ogm-aardvark/source.md
+++ b/docs/ogm-aardvark/source.md
@@ -1,10 +1,7 @@
 ---
 layout: default
 title: Source
-
 parent: OGM Aardvark
-grand_parent: Current Schema
-
 nav_order: 24
 ---
 

--- a/docs/ogm-aardvark/spatial-coverage.md
+++ b/docs/ogm-aardvark/spatial-coverage.md
@@ -2,7 +2,6 @@
 layout: default
 title: Spatial Coverage
 parent: OGM Aardvark
-grand_parent: Current Schema
 nav_order: 17
 ---
 

--- a/docs/ogm-aardvark/subject.md
+++ b/docs/ogm-aardvark/subject.md
@@ -2,7 +2,6 @@
 layout: default
 title: Subject
 parent: OGM Aardvark
-grand_parent: Current Schema
 nav_order: 10
 ---
 

--- a/docs/ogm-aardvark/suppressed.md
+++ b/docs/ogm-aardvark/suppressed.md
@@ -1,10 +1,7 @@
 ---
 layout: default
 title: Suppressed
-
 parent: OGM Aardvark
-grand_parent: Current Schema
-
 nav_order: 40
 ---
 

--- a/docs/ogm-aardvark/temporal-coverage.md
+++ b/docs/ogm-aardvark/temporal-coverage.md
@@ -2,7 +2,6 @@
 layout: default
 title: Temporal Coverage
 parent: OGM Aardvark
-grand_parent: Current Schema
 nav_order: 13
 ---
 

--- a/docs/ogm-aardvark/theme.md
+++ b/docs/ogm-aardvark/theme.md
@@ -2,7 +2,6 @@
 layout: default
 title: Theme
 parent: OGM Aardvark
-grand_parent: Current Schema
 nav_order: 11
 ---
 

--- a/docs/ogm-aardvark/title.md
+++ b/docs/ogm-aardvark/title.md
@@ -2,7 +2,6 @@
 layout: default
 title: Title
 parent: OGM Aardvark
-grand_parent: Current Schema
 nav_order: 1
 ---
 

--- a/docs/ogm-aardvark/wxs-identifier.md
+++ b/docs/ogm-aardvark/wxs-identifier.md
@@ -1,10 +1,7 @@
 ---
 layout: default
 title: WxS Identifier
-
 parent: OGM Aardvark
-grand_parent: Current Schema
-
 nav_order: 34
 ---
 

--- a/docs/upgrading.md
+++ b/docs/upgrading.md
@@ -1,9 +1,9 @@
 ---
 layout: default
 title: Upgrading
-nav_order: 2
+nav_order: 4
 has_toc: false
-parent: Current Schema
+parent: Helpful Resources
 
 ---
 


### PR DESCRIPTION
Addresses part of https://github.com/OpenGeoMetadata/opengeometadata.github.io/issues/36:
* Makes the OGM Aardvark table the new landing page when clicking on "Current Schema."
* Renames the current "Current Schema" landing page to "About OGM Aardvark." This page is no longer accessed through the navigation, but instead through a button on the new Current Schema landing page.
* Moves "Upgrading" to "Helpful Resources." Adds a button linking to it on the new Current Schema landing page.

Note that I'm having trouble testing the internal links when I launch the code locally, but I *think* they should work properly once deployed. 