### PR TITLE
Child toc cleanup

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
 # opengeometadata.github.io
 
-This repository consists of the Jekyll static site generator for the [OpenGeoMetadata web site](https://opengeometadata.github.io). All questions about this repository and contributing to it or other elements of the OpenGeoMetadata project can be directed to geoblacklight-working-group@googlegroups.com.
+This repository consists of the Jekyll static site generator for the [OpenGeoMetadata web site](https://opengeometadata.github.io) using a theme from Just the Docs.  For guidance on controlling things like the site navigation and tables of contents, see the [Just the Docs](https://just-the-docs.github.io/just-the-docs/) website.
+
+All questions about this repository and contributing to it or other elements of the OpenGeoMetadata project can be directed to geoblacklight-working-group@googlegroups.com.

--- a/docs/1.0-geometry-type.md
+++ b/docs/1.0-geometry-type.md
@@ -2,12 +2,9 @@
 layout: default
 title: Geometry Type
 nav_exclude: true
-
 ---
-# Geometry Type
-{: .no_toc }
-----------
 
+# Geometry Type
 
 ## GeoBlacklight 1.0 Geometry Type Vocabulary
 

--- a/docs/1.0-geometry-type.md
+++ b/docs/1.0-geometry-type.md
@@ -1,7 +1,6 @@
 ---
 layout: default
 title: Geometry Type
-has_children: false
 nav_exclude: true
 
 ---

--- a/docs/about-ogm-aardvark.md
+++ b/docs/about-ogm-aardvark.md
@@ -1,7 +1,6 @@
 ---
 layout: default
 title: About OGM Aardvark
-has_children: false
 nav_exclude: true
 
 ---

--- a/docs/format-values.md
+++ b/docs/format-values.md
@@ -1,7 +1,6 @@
 ---
 layout: default
 title: Format Values
-has_children: false
 nav_exclude: true
 
 ---

--- a/docs/helpful-resources.md
+++ b/docs/helpful-resources.md
@@ -3,7 +3,6 @@ layout: default
 title: Helpful Resources
 nav_order: 5
 has_children: true
-has_toc: true
 ---
 
 # Helpful Resources


### PR DESCRIPTION
- Removed unnecessary `has_toc` and `has_children` from frontmatter
  (which are only needed when changing default behavior)
- Added note to README about "Just the Docs"
  (which explains how the site navigation and TOCs work)