### PR TITLE
URI to Field Name and minor copyedits

### DIFF
--- a/docs/aardvark-gbl-1-crosswalk.md
+++ b/docs/aardvark-gbl-1-crosswalk.md
@@ -7,7 +7,7 @@ The following chart shows the full Aardvark schema and which GBL 1.0 fields can 
 
 ## Elements without a crosswalk
 
-Most of the elements from GBL 1.0 can be crosswalked directly into OGM Aardvark. The values for these elements are the same - only the URI name has changed or the field has been converted to an array.  
+Most of the elements from GBL 1.0 can be crosswalked directly into OGM Aardvark. The values for these elements are the same - only the field name has changed or the field has been converted to an array.  
 
 However, there are three elements in GBL 1.0 that do not directly translate into OGM Aardvark. While they have been replaced with similar fields in OGM Aardvark, the **values themselves** would need to be altered during crosswalking.
 
@@ -24,4 +24,4 @@ However, there are three elements in GBL 1.0 that do not directly translate into
 **Is Part Of (`dct_isPartOf_sm`)**
 
 * GBL 1.0 Description: This multi-valued GBL 1.0 plain text field is for writing out the name of a collection. Example: `dct_isPartOf_sm:"Village Maps of India"`
-* Similar Aardvark element: The URI is the same in Aardvark, but it is now a non-literal field. The value must be one or more IDs that reference another record within the system. Example: `dct_isPartOf_sm:"princeton-z603r079s"`
+* Similar Aardvark element: The field name is the same in Aardvark, but it is now a non-literal field. The value must be one or more IDs that reference another record within the system. Example: `dct_isPartOf_sm:"princeton-z603r079s"`

--- a/docs/about-ogm-aardvark.md
+++ b/docs/about-ogm-aardvark.md
@@ -15,9 +15,9 @@ Details about the OpenGeoMetadata metadata schema, OGM Aardvark
 *   **GBL 1.0**: The legacy metadata schema designed for GeoBlacklight versions 2.0-3.7. [The schema is documented on this Legacy page.](gbl-1.0.md)
 *   **OGM Aardvark**: The new metadata schema that is compatible with GeoBlacklight version 4.0.
 *   **GeoBlacklight**: When spelled out, GeoBlacklight refers to [the application itself](https://geoblacklight.org), not its namesake legacy metadata schema, GBL 1.0.
-*   **URI**: This is the name we give to the metadata element itself. For example, the URI for the Subject field is `dct_subject_sm`. 
-*   **Namespace**: This is how we signify which family of standards or schemas an element belongs to. For the GeoBlacklight schema, this takes the form of the URI’s prefix. For the URI `dct_subject_sm`,  `dct_` is the prefix and signifies that this element is from Dublin Core.
-*   **Solr field type**: This is the suffix appended to the URI and indicates what kind of Solr field should be indexed. For `dct_subject_sm`, the `_sm` stands for String Multiple. It indicates that the field type is a string and that it can have multiple values.
+*   **Field name**: This is the name we give to the metadata element itself. For example, the field name for the Subject field is `dct_subject_sm`.
+*   **Namespace**: This is how we signify which family of standards or schemas an element belongs to. For the GeoBlacklight schema, this takes the form of the field name's prefix. For `dct_subject_sm`,  `dct_` is the prefix and signifies that this element is from Dublin Core.
+*   **Solr field type**: This is the suffix appended to the field name and indicates what kind of Solr field should be indexed. For `dct_subject_sm`, the `_sm` stands for String Multiple. It indicates that the field type is a string and that it can have multiple values.
 *   **Value**: This is the information that is entered in a field. It may be free text (literal value) or a URI/code (nonliteral value).
 
 OGM Aardvark is a discovery metadata schema for geospatial resources. It was intentionally developed with cross-application in mind and can be used to describe geospatial assets of all kinds.
@@ -56,7 +56,7 @@ The minimal nature of the original GeoBlacklight schema combined with the growin
 
 The new set of rights elements are:
 
-| Label              | URI                     | Description and Entry Guidelines |
+| Label              | Field Name                     | Description and Entry Guidelines |
 |:-------------------|:------------------------|:---------------------------------|
 | Access Rights      | `dct_accessRights_s`    | One of two possible values, "Public" or "Restricted"; controls whether a user can preview or download an item. This element replaces `dc_rights_s`. |
 | Rights             | `dct_rights_sm`         | Free-text field for generic, catch-all access and usage rights. Can include clickable links. |
@@ -73,7 +73,7 @@ GeoBlacklight version 3.4 and earlier has an Item Relations widget that displays
 
 The new set of relationship elements are:
 
-| Label              | URI                     | Description and Entry Guidelines |
+| Label              | Field Name                     | Description and Entry Guidelines |
 |:-------------------|:------------------------|:---------------------------------|
 | Source             | `dct_source_sm`         | For items that have been derived from another item (e.g. a digitized shapefile from a historical map). |
 | Is Part Of         | `dct_isPartOf_sm`       | For items that are a subset of another item (e.g. a page in a book). This value type is changing from free-text in Version 1.0 to an ID (slug) in the new schema. |
@@ -84,7 +84,7 @@ The new set of relationship elements are:
 | Relation            | `dct_relation_sm`      | For a general purpose relation.  |
 
 
-#### Consistent namespaces for all metadata element URIs
+#### Consistent namespaces for all metadata element field names
 
 OGM Aardvark gives preference to elements found in established schemas over custom fields.
 
@@ -96,7 +96,7 @@ OGM Aardvark gives preference to elements found in established schemas over cust
 
 #### Multivalued elements whenever possible
 
-The original schema features several descriptive metadata fields that only accept one value. The new schema expands many of these to multiple. This changes the URI suffix from `_s` to` _sm`. Although it will not affect the GeoBlacklight functionality, this practice may conflict with indexing, as Solr will treat `dct_publisher_s` as a different field than `dct_publisher_sm`.
+The original schema features several descriptive metadata fields that only accept one value. The new schema expands many of these to multiple. This changes the field name suffix from `_s` to` _sm`. Although it will not affect the GeoBlacklight functionality, this practice may conflict with indexing, as Solr will treat `dct_publisher_s` as a different field than `dct_publisher_sm`.
 
 #### More intuitive name for unique key
 
@@ -158,6 +158,3 @@ Refinements to OpenGeoMetadata have continued through the work of the ongoing Me
 * Lena Denis (Johns Hopkins University)
 * Marc McGee (Harvard University)
 * Rebecca Seifried (UMass Amherst)
-
-
-

--- a/docs/create-metadata.md
+++ b/docs/create-metadata.md
@@ -1,8 +1,8 @@
-# Creating Metadata
+# Create Metadata
 How to create metadata records in the OpenGeoMetadata schema
 
 
-## Authoring
+## Author new metadata
 
 Step 1 of the metadata workflow is to create or collect original metadata for each layer. Depending upon the type of resource and a repository’s chosen workflows, the format of the original metadata may be in different standards or schemas.
 
@@ -16,7 +16,7 @@ The most commonly used tool for creating geospatial metadata is Esri’s ArcCata
 
 **Option B: Create metadata in the OGM schema directly**
 
-Other repositories skip Option A and create records directly in the OpenGeoMetadata metadata schema. Although users benefit from the more complete information that can be added to an FGDC or ISO document, these standards are not needed to run GeoBlacklight. These repositories often use a spreadsheet or a Dublin-Core-based metadata editor to create the records. Scripts can be used to convert spreadsheets (in .csv format) to JSON in the OpenGeoMetadata schema. See [Workflows and Tools](/workflows-and-tools.md) for example scripts.
+Other repositories skip Option A and create records directly in the OpenGeoMetadata metadata schema. Although users benefit from the more complete information that can be added to an FGDC or ISO document, these standards are not needed to run GeoBlacklight. These repositories often use a spreadsheet or a Dublin-Core-based metadata editor to create the records. Scripts can be used to convert spreadsheets (in .csv format) to JSON in the OpenGeoMetadata schema. See [Metadata Processing Scripts](../scripts) for example scripts.
 
 ### For resources with existing metadata files
 
@@ -31,38 +31,28 @@ A large amount of publicly available geospatial data does not have ISO or FGDC. 
 
 Scanned maps from library catalogs should have MARC catalog records, and they should be able to supply the repository with metadata in the .MRC or MARC XML file format.
 
-## Transforming
+---
+
+## Transform existing metadata
 
 If the metadata records are in a non-OpenGeoMetadata standard, the next step is to convert or transfer information from some or all of the fields to the OpenGeoMetadata schema. The result of this process is one or more JSON files that will be parsed and indexed by Solr. These JSON files will serve as the content to be shown in the GeoBlacklight application.
 
 ### Transformation workflows
 
+!!! tip
+
+	* JSON files in the OpenGeoMetadata schema do not need to be stored with the data/items they are referencing.
+	* Multiple items can be referenced in a single JSON file.
+	* Some fields will contain the same values for each item (e.g. `gbl_mdVersion_s`)
+	* See [Metadata Processing Scripts](../scripts) to view custom scripts and tools for additional metadata authoring techniques.
 
 Most institutions have their own unique set of tools and workflows to perform this transformation.  These workflows may differ depending on the type of item to be referenced.  In most cases, automation of this process is desired, although it is possible to create the JSON files manually.
 
-The process, whether automated or manual, typically involves parsing the existing metadata record, extracting the values from selected fields and inserting the value into a new JSON document under the corresponding OpenGeoMetadata schema field. In most cases the values can simply be copied over as is, although some additional formatting may be necessary.
-
-See [Metadata Scripts](scripts.md) to view custom scripts and tools for additional metadata authoring techniques.
-
-!!! tip
-
-	* The JSON files in the OpenGeoMetadata schema do not need to be stored with the data/items they are referencing.
-	* Multiple items can be referenced in a single JSON file.
-	* Some fields will contain the same values for each item (e.g. `gbl_mdVersion_s`)
-
-### Example
-
-
-A finished metadata file could look like the following example in ISO 19139 format:
-
-![ISO Metadata ](images/ISO_snippet.png)
-
-The process of transforming metadata from the above formats to the OpenGeoMetadata schema involves mapping or “crosswalking” fields from one format to another.
+The process, whether automated or manual, typically involves parsing the existing metadata record, extracting the values from selected fields and inserting the value into a new JSON document under the corresponding OpenGeoMetadata schema field. This process is called mapping or "crosswalking." In most cases the values can simply be copied over as is, although some additional formatting may be necessary.
 
 ![ISO to GBL Crosswalk](images/ISO-GBL.jpg)
 
-
-## Example workflow
+### Example
 
 At Stanford, the [metadata records](https://github.com/OpenGeoMetadata/edu.stanford.purl) are natively authored in ESRI ArcCatalog and then transformed into ISO 19139. The ISO 19139 records are then transformed to MODS for the library catalog and GeoBlacklight for the [GeoBlacklight catalog](https://earthworks.stanford.edu/).
 

--- a/docs/gbl-1.0.md
+++ b/docs/gbl-1.0.md
@@ -9,7 +9,7 @@ hide:
 ---
 
 
-| Label 					                	| URL                    | Required | Recommended |
+| Label 					                	| Field Name             | Required | Recommended |
 |:----------------------------------|:-----------------------|:--------:|:-----------:|
 | [Identifier](#identifier)					| `dc_identifier_s`      | X        |             |
 | [Rights](#rights)					    		| `dc_rights_s`          | X        |             |
@@ -43,7 +43,7 @@ hide:
 
 | Label							    | Identifier|
 |:----------------------|:-----------|
-| uri					  	    	| `dc_identifier_s`|
+| Field Name					  	    	| `dc_identifier_s`|
 | Required				  		| yes|
 | Type							    | string|
 | Description					  | Unique identifier for layer as a URI. It should be globally unique across all institutions, assumed not to be end-user visible|
@@ -58,7 +58,7 @@ hide:
 
 | Label							| Rights|
 |:----------------------|:-----------|
-| uri							| `dc_rights_s`|
+| Field Name							| `dc_rights_s`|
 | Required						| yes|
 | Type							| string|
 | Description					| Signals access in the geoportal and is indicated by a padlock icon. Users need to sign in to download restricted items|
@@ -72,7 +72,7 @@ hide:
 
 | Label							| Title|
 |:----------------------|:-----------|
-| uri							| `dc_title_s`|
+| Field Name							| `dc_title_s`|
 | Required						| yes|
 | Type							| string|
 | Description					| The name of the resource|
@@ -86,7 +86,7 @@ hide:
 
 | Label							| Provenance|
 |:----------------------|:-----------|
-| uri							| `dct_provenance_s`|
+| Field Name							| `dct_provenance_s`|
 | Required						| yes|
 | Type							| string|
 | Description					| The name of the institution that holds the resource or acts as the custodian for the metadata record|
@@ -100,7 +100,7 @@ hide:
 
 | Label							| Schema Version|
 |:----------------------|:-----------|
-| uri							| `geoblacklight_version`	|
+| Field Name							| `geoblacklight_version`	|
 | Required						| yes|
 | Type							| string|
 | Description					| Indicates which version of the GeoBlacklight schema is in use|
@@ -114,7 +114,7 @@ hide:
 
 | Label							| Slug|
 |:----------------------|:-----------|
-| uri							| `layer_slug_s`|
+| Field Name							| `layer_slug_s`|
 | Required						| yes|
 | Type							| string|
 | Description					| This is a string appended to the base URL of a GeoBlacklight installation to create a unique landing page for each resource. It is visible to the user and serves the purpose of forming a persistent URL for each catalog item.|
@@ -128,7 +128,7 @@ hide:
 
 | Label 						| Bounding Box|
 |:----------------------|:-----------|
-| uri							| `solr_geom`|
+| Field Name							| `solr_geom`|
 | Required						| yes|
 | Type							| string|
 | Description					| The rectangular extents of the resource. Note that this field is indexed as a Solr spatial (RPT) field|
@@ -142,7 +142,7 @@ hide:
 
 | Label 						| Solr Year|
 |:----------------------|:-----------|
-| uri							| `solr_year_i`|
+| Field Name							| `solr_year_i`|
 | Required						| no|
 | Type							| integer|
 | Description					| A four digit integer representing a year of temporal coverage or date issued for the resource. This field is used to populate the Year facet and the optional [Blacklight Range Limit gem](https://github.com/projectblacklight/blacklight_range_limit)|
@@ -156,7 +156,7 @@ hide:
 
 | Label							| Creator|
 |:----------------------|:-----------|
-| uri 							| `dc_creator_sm`|
+| Field Name 							| `dc_creator_sm`|
 | Required						| no|
 | Type							| array|
 | Description					| The person(s) or organization that created the resource|
@@ -170,7 +170,7 @@ hide:
 
 | Label| Description|
 |:----------------------|:-----------|
-| uri							| `dc_description_s`|
+| Field Name							| `dc_description_s`|
 | Required						| no|
 | Type							| string|
 | Description					| At minimum, this is a reiteration of the title in sentence format. Other relevant information, such as data creation methods, data sources, and special licenses, may also be included.|
@@ -184,7 +184,7 @@ hide:
 
 | Label							| Format|
 |:----------------------|:-----------|
-| uri							| `dc_format_s`|
+| Field Name							| `dc_format_s`|
 | Required						| yes, if download link is included AND if download URL is configured as a single key:value pair|
 | Type							| string|
 | Description					| This indicates the file format of the data. If a download link is included, this value displays on the item page in the button under the download widget|
@@ -198,7 +198,7 @@ hide:
 
 | Label							| Language|
 |:----------------------|:-----------|
-| uri							| `dc_language_sm`|
+| Field Name							| `dc_language_sm`|
 | Required						| no|
 | Type							| array|
 | Description					| Indicates the language of the data or map|
@@ -212,7 +212,7 @@ hide:
 
 | Label							| Publisher|
 |:----------------------|:-----------|
-| uri							| `dc_publisher_s`|
+| Field Name							| `dc_publisher_s`|
 | Required						| no|
 | Type							| array|
 | Description					| The organization that made the original resource available|
@@ -226,7 +226,7 @@ hide:
 
 | Label							| Source|
 |:----------------------|:-----------|
-| uri							| `dc_source_sm`|
+| Field Name							| `dc_source_sm`|
 | Required						| no|
 | Type							| array|
 | Description					| This is used to indicate parent/child relationships between data layers and activates the Data Relations widget in GeoBlacklight|
@@ -240,7 +240,7 @@ hide:
 
 | Label							| Subject|
 |:----------------------|:-----------|
-| uri							| `dc_subject_sm`|
+| Field Name							| `dc_subject_sm`|
 | Required						| no|
 | Type							| array|
 | Description					| These are theme or topic keywords|
@@ -254,7 +254,7 @@ hide:
 
 | Label							| Type|
 |:----------------------|:-----------|
-| uri							| `dc_type_s`|
+| Field Name							| `dc_type_s`|
 | Required						| no|
 | Type							| string|
 | Description					| This is a general element to indicate the larger genre of the resource|
@@ -268,7 +268,7 @@ hide:
 
 | Label							| Is Part Of|
 |:----------------------|:-----------|
-| uri							| `dct_isPartOf_sm`|
+| Field Name							| `dct_isPartOf_sm`|
 | Required						| no|
 | Type							| array|
 | Description					| Holding entity for the layer, such as the title of a collection|
@@ -282,7 +282,7 @@ hide:
 
 | Label							| Date Issued|
 |:----------------------|:-----------|
-| uri							| `dct_issued_s`|
+| Field Name							| `dct_issued_s`|
 | Required						| no|
 | Type							| string|
 | Description					| This is the publication date for the resource|
@@ -296,7 +296,7 @@ hide:
 
 | Label							| References|
 |:----------------------|:-----------|
-| uri							| `dct_references_s`|
+| Field Name							| `dct_references_s`|
 | Required						| no|
 | Type							| string|
 | Description					| This element is a hash of key/value pairs for different types of external links. It integrates external services and references using the CatInterOp approach|
@@ -310,7 +310,7 @@ hide:
 
 | Label							| Spatial Coverage|
 |:----------------------|:-----------|
-| uri							| `dct_spatial_sm`|
+| Field Name							| `dct_spatial_sm`|
 | Required						| no|
 | Type							| array|
 | Description					| This field is for place name keywords|
@@ -324,7 +324,7 @@ hide:
 
 | Label							| Temporal Coverage|
 |:----------------------|:-----------|
-| uri							| `dct_temporal_sm`|
+| Field Name							| `dct_temporal_sm`|
 | Required						| no|
 | Type							| array|
 | Description					| This represents the "Ground Condition" of the resource, meaning the time period data was collected or is intended to represent. Displays on the item page in the Year value|
@@ -338,7 +338,7 @@ hide:
 
 | Label							| Geometry Type|
 |:----------------------|:-----------|
-| uri							| `layer_geom_type_s`|
+| Field Name							| `layer_geom_type_s`|
 | Required						| no|
 | Type							| string|
 | Description					| This element shows up as Data type in GeoBlacklight, and each value has an associated icon|
@@ -352,7 +352,7 @@ hide:
 
 | Label							| Layer ID|
 |:----------------------|:-----------|
-| uri							| `layer_id_s`|
+| Field Name							| `layer_id_s`|
 | Required						| no|
 | Type							| string|
 | Description					| Indicates the layer id for any WMS or WFS web services listed in the `dct_references_s` field|
@@ -366,7 +366,7 @@ hide:
 
 | Label							| Modified Date|
 |:----------------------|:-----------|
-| uri							| `layer_modified_dt`|
+| Field Name							| `layer_modified_dt`|
 | Required						| no|
 | Type							| date-time|
 | Description					| Last modification date for the metadata record|
@@ -380,7 +380,7 @@ hide:
 
 | Label							| Suppressed|
 |:----------------------|:-----------|
-| uri							| `suppressed_b`|
+| Field Name							| `suppressed_b`|
 | Required						| no|
 | Type							| boolean|
 | Description					| If set to True, the record will not appear in search results. If is still accessible from the Data Relations widget and via direct URL.|

--- a/docs/index-in-solr.md
+++ b/docs/index-in-solr.md
@@ -1,20 +1,15 @@
-# Publishing Metadata in Solr
-
-How to publish metadata records in Solr for GeoBlacklight integration
+# Index Metadata in Solr
 
 !!! note
 
 	This page is a work in progress and needs more information.
 
+Metadata records must be indexed in Solr in order to integrate with GeoBlacklight. The Solr application identifies each metadata record as a “document.” The process of adding documents to Solr is called “indexing.”
 
-## Add metadata records to Solr
-
-Metadata for GeoBlacklight instances is stored and indexed in Solr. The Solr application identifies each metadata record as a “document.” The process of adding documents to Solr is called “indexing.”
-
-**Option A: Manually indexing**
+## Option A: Indexing manually
 
 If you have access to your Solr Dashboard panel, you can add records manually by pasting them into the Documents pane.
 
-**Option B: Indexing via scripts**
+## Option B: Indexing via scripts
 
-It is often more practical to use a process for batch adding, updating, and deleting the records. Most of the available processes are in the form of command-line scripts. See the [Metadata Scripts](scripts.md) for examples.
+It is often more practical to use a process for batch adding, updating, and deleting the records. Most of the available processes are in the form of command-line scripts. See the [Metadata Scripts](../scripts) for examples.

--- a/docs/share-on-ogm.md
+++ b/docs/share-on-ogm.md
@@ -77,7 +77,7 @@ A hashed directory structure makes it easy to include additional materials and d
 ```
 
 !!! note
-	
+
 	Institutions may choose to use a combination of structures, such as hashed directories within categorical folders.
 
 
@@ -85,7 +85,7 @@ A hashed directory structure makes it easy to include additional materials and d
 
 Determine the file-naming rules for your metadata. There are two main approaches to naming metadata files: naming by the item's ID or naming by the file's metadata standard.
 
-### 1. Naming by item ID
+### Naming by item ID
 
 
 Each record has a unique filename based on the item’s ID. This allows multiple records to be stored in the same directory. See the [edu.harvard](https://github.com/OpenGeoMetadata/edu.harvard) repository for an example:
@@ -100,7 +100,7 @@ Each record has a unique filename based on the item’s ID. This allows multiple
            ...
 ```
 
-### 2. Naming by metadata standard
+### Naming by metadata standard
 
 
 All records use the same filename pattern, such as `*/geoblacklight.json` or `*/fgdc.json`. This requires each layer to have its own folder.

--- a/docs/solr-field-suffixes.md
+++ b/docs/solr-field-suffixes.md
@@ -5,19 +5,17 @@ hide:
 
 # Solr Field Suffixes
 
-The following suffixes are part of the OGM Aardvark schema and may be used by custom fields. 
+The following suffixes are part of the OGM Aardvark schema and may be used by custom fields.
 
 | Field Suffix | Type                     | Description                     | Example   |
 |:-------------|:-------------------------|:--------------------------------|:----------|
 | `_b`         | Boolean                  | Values can be `true` or `false` | `gbl_georeferenced_b`|
 | `_im`        | Integer, multivalued     | Digits                          | `gbl_indexYear_im`|
 | `_drsim`     | Date range, multivalued  | Date range in a specified string format: "[1980 TO 1995]" | `gbl_dateRange_drsim` |
-| `_dt`        | Date                     | Date and time in a specified string format: "YYYY-MM-DDThh:mm:ssZ" | `gbl_mdModified_dt`|
+| `_dt`        | Date                     | Date and time in a specified string format: "YYYY-MM-DDThh:<zero-width space>mm:ssZ" | `gbl_mdModified_dt`|
 | `_s`         | String                   | Single string of text           | `dct_title_s` |
 | `_sm`        | String, multivalued      | Multiple strings of text        | `dct_subject_sm` |
 
 !!! tip
 
 	For a full list of spatial field types and their suffixes used in GeoBlacklight, see [https://github.com/geoblacklight/geoblacklight/blob/main/solr/conf/schema.xml#L14](https://github.com/geoblacklight/geoblacklight/blob/main/solr/conf/schema.xml#L14).
-
-

--- a/docs/tables/ogm-aardvark-fields.csv
+++ b/docs/tables/ogm-aardvark-fields.csv
@@ -1,4 +1,4 @@
-Label,URI,Obligation
+Label,Field Name,Obligation
 ==**[Access Rights](ogm-aardvark/access-rights.md)**==,`dct_accessRights_s`,==**Required**==
 [Alternative Title](ogm-aardvark/alternative-title.md),`dct_alternative_sm`,Optional
 [Bounding Box](ogm-aardvark/bounding-box.md),`dcat_bbox`,Suggested

--- a/docs/tables/ogm-accessRights.csv
+++ b/docs/tables/ogm-accessRights.csv
@@ -1,5 +1,5 @@
 Label,Access Rights
-URI,dct_accessRights_s
+Field Name,dct_accessRights_s
 Obligation,Required
 Multivalued,false
 Field type,string

--- a/docs/tables/ogm-gbl1.csv
+++ b/docs/tables/ogm-gbl1.csv
@@ -1,5 +1,5 @@
 Aardvark Label,OGM Aardvark,GBL 1.0,Note
-Access Rights,`dct_accessRights_s`,`dc_rights_s`,new URI name
+Access Rights,`dct_accessRights_s`,`dc_rights_s`,new field name
 Alternative Title,`dct_alternative_sm`,-,new field
 Bounding Box,`dcat_bbox`,`solr_geom`,new field
 Centroid,`dcat_centroid`,-,new field
@@ -11,18 +11,18 @@ File Size,`gbl_fileSize_s`,-,new field
 Format,`dct_format_s`,`dc_format_s`,new namespace
 Geometry,`locn_geometry`,`solr_geom`,new field
 Georeferenced,`gbl_georeferenced_b`,-,new field
-ID,`id`,`layer_slug_s`,new URI name
+ID,`id`,`layer_slug_s`,new field name
 Identifier,`dct_identifier_sm`,`dc_identifier_s`,new namespace; single to multi-valued
-Index Year,`gbl_indexYear_im`,`solr_year_i`,new URI name; single to multi-valued
+Index Year,`gbl_indexYear_im`,`solr_year_i`,new field name; single to multi-valued
 Is Part Of,`dct_isPartOf_sm`,-,new value type (see Elements without a crosswalk)
 Is Replaced By,`dct_isReplacedBy_sm`,-,new field
 Keyword,`dcat_keyword_sm`,-,new field
 Language,`dct_language_sm`,`dc_language_s or _sm`,new namespace; single to multi-valued
 License,`dct_license_sm`,-,new field
 Member Of,`pcdm_memberOf_sm`,-,new field
-Metadata Version,`gbl_mdVersion_s`,`geoblacklight_version`,new URI name
-Modified,`gbl_mdModified_dt`,`layer_modified_dt`,new URI name
-Provider,`schema_provider_s`,`dct_provenance_s`,new URI name
+Metadata Version,`gbl_mdVersion_s`,`geoblacklight_version`,new field name
+Modified,`gbl_mdModified_dt`,`layer_modified_dt`,new field name
+Provider,`schema_provider_s`,`dct_provenance_s`,new field name
 Publisher,`dct_publisher_sm`,`dc_publisher_s`,new namespace; single to multi-valued
 References,`dct_references_s`,`dct_references_s`,no change
 Relation,`dct_relation_sm`,-,new field
@@ -39,7 +39,7 @@ Temporal Coverage,`dct_temporal_sm`,`dct_temporal_sm`,no change
 Theme,`dcat_theme_sm`,-,new field
 Title,`dct_title_s`,`dc_title_s`,new namespace
 Version,`dct_isVersionOf_sm`,-,new field
-WxS Identifier,`gbl_wxsIdentifier_s`,`layer_id_s`,new URI name
+WxS Identifier,`gbl_wxsIdentifier_s`,`layer_id_s`,new field name
 -,-,`dc_type_s`,deprecated field
 -,-,`layer_geom_type_s`,deprecated field
 -,-,`dc_isPartOf_sm`,"deprecated literal field, replaced by nonliteral dct_isPartOf_sm,, which takes an ID"

--- a/docs/temporal-fields.md
+++ b/docs/temporal-fields.md
@@ -2,12 +2,12 @@
 
 Aardvark has four fields in the "temporal" group. Having multiple temporal fields allows for flexibility in describing the date of a resource, allowing users to easily find records by way of text search, facet filtering, and time slider widgets (an optional customization in the GeoBlacklight software). In some cases, the same value might be used for more than one field.
 
-| Field                 | Obligation |
-|:----------------------|:---------|
-| [Temporal Coverage](../ogm-aardvark/#temporal-coverage) | Suggested |
-| [Date Issued](../ogm-aardvark/#date-issued)             |           |
-| [Index Year](../ogm-aardvark/#index-year)               | Suggested |
-| [Date Range](../ogm-aardvark/#date-range)               |           |
+| Field | Field Name | Obligation |
+|:------|:-----------|:-----------|
+| [Temporal Coverage](../ogm-aardvark/#temporal-coverage) | `dct_temporal_sm` | Suggested |
+| [Date Issued](../ogm-aardvark/#date-issued)             | `dct_issued_s` ||
+| [Index Year](../ogm-aardvark/#index-year)               | `gbl_indexYear_im` | Suggested |
+| [Date Range](../ogm-aardvark/#date-range)               | `gbl_dateRange_drsim` ||
 
 
 ## Temporal Coverage
@@ -21,7 +21,7 @@ This is a descriptive, free-text field that is intended to describe the time per
 ```
 
 ## Date Issued
-This is an optional field for describing the date of an item's publication. Although optional, this field is often useful when a clear `Temporal Coverage` value is not present. For example, a dataset with uncertain lineage may at least have a date of last update. Generally it should be structured as a single year: `YYYY`, but more precise dates can take the ISO format withtout the time value: `YYYY-MM-DD` or `YYYY-MM`.
+his is an optional field for describing the date of an item's publication. Although optional, this field is often useful when a clear temporal coverage value is not present. For example, a dataset with uncertain lineage may at least have a date of last update. Generally it should be structured as a single year: `YYYY`, but more precise dates can take the ISO format withtout the time value: `YYYY-MM-DD` or `YYYY-MM`.
 
 ```
 "1999"
@@ -31,7 +31,7 @@ This is an optional field for describing the date of an item's publication. Alth
 ```
 
 ## Index Year
-This is a suggested field for describing the date depicted in a resource. It is the only integer field in the "temporal" group and is formatted as an array of multiple values. The default GeoBlacklight application uses this field in the "Year" facet, allowing users to filter search results by year. It is also used to power customizable time-slider widgets that rely on integers for dates.
+This is a suggested field for describing the date depicted in a resource. It is the only integer field in the temporal group and is formatted as an array of multiple values. The default GeoBlacklight application uses this field in the "Year" facet, allowing users to filter search results by year. It is also used to power customizable time-slider widgets that rely on integers for dates.
 
 ```
 [1985]
@@ -41,7 +41,6 @@ This is a suggested field for describing the date depicted in a resource. It is 
 ```
 
 ## Date Range
-
 This optional field is not yet supported by GeoBlacklight software, but its intent is to power time widgets that use a date range (an optional customization to the software). The field is formatted as a start date and end date in the Solr date range field convention.
 
 ```

--- a/docs/temporal-fields.md
+++ b/docs/temporal-fields.md
@@ -21,7 +21,7 @@ This is a descriptive, free-text field that is intended to describe the time per
 ```
 
 ## Date Issued
-his is an optional field for describing the date of an item's publication. Although optional, this field is often useful when a clear temporal coverage value is not present. For example, a dataset with uncertain lineage may at least have a date of last update. Generally it should be structured as a single year: `YYYY`, but more precise dates can take the ISO format withtout the time value: `YYYY-MM-DD` or `YYYY-MM`.
+This is an optional field for describing the date of an item's publication. Although optional, this field is often useful when a clear temporal coverage value is not present. For example, a dataset with uncertain lineage may at least have a date of last update. Generally it should be structured as a single year: `YYYY`, but more precise dates can take the ISO format without the time value: `YYYY-MM-DD` or `YYYY-MM`.
 
 ```
 "1999"

--- a/docs/view-solr-metadata.md
+++ b/docs/view-solr-metadata.md
@@ -1,35 +1,36 @@
 # View Solr Metadata in GeoBlacklight
 
-GeoBlacklight will display the raw metadata for a published item. Just append one of the following extensions to the end of an item's show page URL:
+GeoBlacklight can display the raw metadata for a published item by appending one of the following extensions to the end of an item's show page URL:
 
 ### `url.xml`
 
-* Produces a Dublin Core XML document in the [OAI_DC schema](https://www.openarchives.org/OAI/2.0/oai_dc.xsd). The fields for this document can be adjusted in the `solr_document.rb`, which is found here: `app/models/solr_document.rb`.
+* Produces a Dublin Core XML document in the [OAI_DC schema](https://www.openarchives.org/OAI/2.0/oai_dc.xsd).
+* The fields for this document can be adjusted in the `solr_document.rb`, which is found here: `app/models/solr_document.rb`.
 
 !!! example
- 
+
 	[https://geo.btaa.org/catalog/145055E1-87EF-4D13-B138-4DC3907F3677.xml](https://geo.btaa.org/catalog/145055E1-87EF-4D13-B138-4DC3907F3677.xml)
 
 ### `url.json`
 
 Depending on your version, this will produce either:
 
-* a nested JSON document of the metadata that appears on the item page. This document can be harvested by the [JSON:API](https://jsonapi.org/) protocol.
+* A nested JSON document of the metadata that appears on the item page (this document can be harvested by the [JSON:API](https://jsonapi.org/) protocol), OR
 
-* a full metadata file for the item as a flat JSON document (GeoBlacklight until version 1.9: .
+* A full metadata file for the item as a flat JSON document (up to GeoBlacklight version 1.9).
 
 !!! example
- 
+
 	[https://geo.btaa.org/catalog/145055E1-87EF-4D13-B138-4DC3907F3677.json](https://geo.btaa.org/catalog/145055E1-87EF-4D13-B138-4DC3907F3677.json)
 
 
 ### `url/raw`
 
-* only available for GeoBlacklight versions 2.0+ 
-* displays the full metadata file for the item as a flat JSON document
+* Only available for GeoBlacklight versions 2.0+.
+* Displays the full metadata file for the item as a flat JSON document.
 
 !!! example
- 
+
 	[https://geo.btaa.org/catalog/145055E1-87EF-4D13-B138-4DC3907F3677/raw](https://geo.btaa.org/catalog/145055E1-87EF-4D13-B138-4DC3907F3677/raw)
 
 
@@ -38,14 +39,12 @@ Depending on your version, this will produce either:
     === "GBL versions 2.0 and beyond"
 
         * `url.xml`: Dublin Core XML document
-        * `url.json`: nested JSON document of only the metadata that appears on the item page.
+        * `url.json`: nested JSON document of only the metadata that appears on the item page
         * `url/raw`: flat JSON document of all metadata associated with the item
 
 
 
     === "GBL < versions 1.9"
-    
+
         * `url.xml`: Dublin Core XML document
         * `url.json`: flat JSON document of all metadata associated with the item
-       
-


### PR DESCRIPTION
Builds on #95 - replaces remnant references to "URIs" with "field names". Also cleans up / streamlines a couple of documentation pages.