### PR TITLE
Update OGM Aardvark schema page

### DIFF
--- a/docs/ogm-aardvark.md
+++ b/docs/ogm-aardvark.md
@@ -1,96 +1,14 @@
 # OpenGeoMetadata (OGM) Aardvark Schema
 
-!!! tip
-	To read more about certain metadata categories (like "Spatial"), click the hyperlinked headings in the table below. 
+!!! info "Definitions"
 
-<div style="float:left; margin-right:5em; line-height:1.1" markdown="1">
+	Mandatory = meets the minimum community standard
 
-#### Descriptive
-- ==[Title](#title) (R)==
-- [Alternative Title](#alternative-title)
-- [Description](#description) (S)
-- [Language](#language) (v)
-- [Display Note](#display-note)
+	Suggested = improves searching and/or citation generation
 
-#### Credits
-- [Creator](#creator) (S)
-- [Publisher](#publisher) (S)
-- [Provider](#provider) (S)
-
-#### Categories
-- ==[Resource Class](#resource-class) (R)== (v)
-- [Resource Type](#resource-type) (S) (v)
-- [Subject](#subject)
-- [Theme](#theme) (v)
-- [Keyword](#keyword)
-
-#### [Temporal :material-link:](../temporal-fields)
-- [Temporal Coverage](#temporal-coverage) (S)
-- [Date Issued](#date-issued)
-- [Index Year](#index-year) (S)
-- [Date Range](#date-range)
-
-</div>
-<div style="float:left; margin-right:5em; line-height:1.1" markdown="1">
-
-#### [Spatial :material-link:](../spatial-fields)
-- [Spatial Coverage](#spatial-coverage) (S)
-- [Geometry](#geometry) (S)
-- [Bounding Box](#bounding-box) (S)
-- [Centroid](#centroid)
-- [Georeferenced](#georeferenced)
-
-#### [Relations :material-link:](../relations-fields)
-- [Relation](#relation)
-- [Member Of](#member-of)
-- [Is Part Of](#is-part-of)
-- [Source](#source)
-- [Is Version Of](#is-version-of)
-- [Replaces](#replaces)
-- [Is Replaced By](#is-replaced-by)
-
-#### Rights
-- [Rights](#rights_1) (S)
-- [Rights Holder](#rights-holder)
-- [License](#license)
-- ==[Access Rights](#access-rights) (R)==
-
-</div>
-<div style="float:left; line-height:1.1" markdown="1">
-
-#### Object
-- [Format](#format) (C) (v)
-- [File Size](#file-size)
-
-#### Links
-- [References](#references) (S)
-- [WxS Identifier](#wxs-identifier) (C)
-
-#### Identifiers
-- ==[ID](#id) (R)==
-- [Identifier](#identifier) (S)
-
-#### Admin
-- ==[Modified](#modified) (R)==
-- ==[Metadata Version](#metadata-version) (R)== (v)
-- [Suppressed](#suppressed)
+{{ read_csv('ogm-aardvark/ogm-aardvark.csv') }}
 
 ----
-
-!!! info "Key"
-
-	==(R)  = Required==
-
-	(C) = Conditionally Required
-
-	(S) = Suggested  
-
-	(v) = Controlled Values
-
-</div>
-
-<br style="clear:left">
-
 
 ## Access Rights
 {{ read_csv('ogm-aardvark/access-rights.csv') }}

--- a/docs/ogm-aardvark.md
+++ b/docs/ogm-aardvark.md
@@ -2,9 +2,11 @@
 
 !!! info "Definitions"
 
-	Mandatory = meets the minimum community standard
+	**Mandatory** = meets the minimum community standard for high-quality metadata
 
-	Suggested = improves searching and/or citation generation
+	**Suggested** = improves searching and/or citation generation
+	
+	To check which fields are required for current GeoBlacklight functionality, see the [GeoBlacklight documentation](https://geoblacklight.org/docs/metadata/)
 
 {{ read_csv('ogm-aardvark/ogm-aardvark.csv') }}
 

--- a/docs/ogm-aardvark/access-rights.csv
+++ b/docs/ogm-aardvark/access-rights.csv
@@ -2,7 +2,7 @@ Label,Access Rights
 URI,https://opengeometadata.org/ogm-aardvark/#access-rights
 Field Name,dct_accessRights_s
 Field Type,String
-Obligation,Required
+Obligation,Mandatory - used to restrict patron access; critical for GeoBlacklight functioning
 Multivalued,False
 Purpose,To clarify to the user if the resource is public (any user can access) or restricted (a user will need to log in to some kind of authentication protocol) and if the application should provide a web service preview and/or a download function.
 Entry Guidelines,Only one of two values are allowed: Public or Restricted.
@@ -10,4 +10,4 @@ Commentary,"This field can be set to ""Public"", which allows users to view and 
 Controlled Vocabulary,Yes - strict
 Example Value,"""Public"""
 Element Set,DCMI
-Group,"[Rights](../ogm-aardvark/#rights)"
+Group,Rights

--- a/docs/ogm-aardvark/alternative-title.csv
+++ b/docs/ogm-aardvark/alternative-title.csv
@@ -10,4 +10,4 @@ Commentary,"For discoverability, improving titles for data is encouraged. This f
 Controlled Vocabulary,No
 Example Value,"[""NEZ H Districts""]"
 Element Set,DCMI
-Group,"[Descriptive](../ogm-aardvark/#descriptive)"
+Group,Descriptive

--- a/docs/ogm-aardvark/bounding-box.csv
+++ b/docs/ogm-aardvark/bounding-box.csv
@@ -2,7 +2,7 @@ Label,Bounding Box
 URI,https://opengeometadata.org/ogm-aardvark/#bounding-box
 Field Name,dcat_bbox
 Field Type,String
-Obligation,Suggested
+Obligation,Mandatory - used in GeoBlacklight software to provide more relevant search results
 Multivalued,False
 Purpose,To support overlap ratio boosting in spatial searches.
 Entry Guidelines,"This should be a bounding box in this format: ENVELOPE(W,E,N,S)."
@@ -10,4 +10,4 @@ Commentary,"If the [Geometry](../ogm-aardvark/#geometry) field uses the ENVELOPE
 Controlled Vocabulary,No
 Example Value,"""ENVELOPE(-111.1, -104.0, 45.0, 40.9)"""
 Element Set,DCAT
-Group,"[Spatial](../ogm-aardvark/#spatial)"
+Group,[Spatial](../spatial-fields)

--- a/docs/ogm-aardvark/bounding-box.csv
+++ b/docs/ogm-aardvark/bounding-box.csv
@@ -2,7 +2,7 @@ Label,Bounding Box
 URI,https://opengeometadata.org/ogm-aardvark/#bounding-box
 Field Name,dcat_bbox
 Field Type,String
-Obligation,Mandatory - used in GeoBlacklight software to provide more relevant search results
+Obligation,Mandatory - used to provide more relevant search results in GeoBlacklight
 Multivalued,False
 Purpose,To support overlap ratio boosting in spatial searches.
 Entry Guidelines,"This should be a bounding box in this format: ENVELOPE(W,E,N,S)."

--- a/docs/ogm-aardvark/centroid.csv
+++ b/docs/ogm-aardvark/centroid.csv
@@ -10,4 +10,4 @@ Commentary,This field is currently only supported by customizations to the GeoBl
 Controlled Vocabulary,No
 Example Value,"""46.4218,-94.087"""
 Element Set,DCAT
-Group,"[Spatial](../ogm-aardvark/#spatial)"
+Group,[Spatial](../spatial-fields)

--- a/docs/ogm-aardvark/creator.csv
+++ b/docs/ogm-aardvark/creator.csv
@@ -2,7 +2,7 @@ Label,Creator
 URI,https://opengeometadata.org/ogm-aardvark/#creator
 Field Name,dct_creator_sm
 Field Type,Array of strings
-Obligation,Suggested
+Obligation,Suggested - helpful for generating citations
 Multivalued,True
 Purpose,To credit the person/organization that collected or authored the resource.
 Entry Guidelines,The suggested controlled vocabulary is the [Library of Congress Name Authority File](https://id.loc.gov/authorities/names.html).
@@ -10,4 +10,4 @@ Commentary,"The distinction between Creator and [Publisher](../ogm-aardvark/#pub
 Controlled Vocabulary,No
 Example Value,"[""Geological Survey (U.S.)""]"
 Element Set,DCMI
-Group,"[Credits](../ogm-aardvark/#credits)"
+Group,Credits

--- a/docs/ogm-aardvark/date-issued.csv
+++ b/docs/ogm-aardvark/date-issued.csv
@@ -2,7 +2,7 @@ Label,Date Issued
 URI,https://opengeometadata.org/ogm-aardvark/#date-issued
 Field Name,dct_issued_s
 Field Type,String
-Obligation,Optional
+Obligation,Suggested - used to generate citations
 Multivalued,False
 Purpose,"To provide the user with the date when an item was published, and to allow administrators to determine the age of the resource."
 Entry Guidelines,"A single year is the preferred format. For more precise dates, use the ISO format without the time value: YYYY-MM-DD or YYYY-MM."
@@ -10,4 +10,4 @@ Commentary,"Although the field is optional, it is often useful when a clear [Tem
 Controlled Vocabulary,No
 Example Value,"""1999"""
 Element Set,DCMI
-Group,"[Temporal](../ogm-aardvark/#temporal)"
+Group,[Temporal](../temporal-fields)

--- a/docs/ogm-aardvark/date-range.csv
+++ b/docs/ogm-aardvark/date-range.csv
@@ -10,4 +10,4 @@ Commentary,"This field is not yet supported by GeoBlacklight, but the applicatio
 Controlled Vocabulary,No
 Example Value,"""[1980 TO 1995]"""
 Element Set,GBL
-Group,"[Temporal](../ogm-aardvark/#temporal)"
+Group,[Temporal](../temporal-fields)

--- a/docs/ogm-aardvark/description.csv
+++ b/docs/ogm-aardvark/description.csv
@@ -2,7 +2,7 @@ Label,Description
 URI,https://opengeometadata.org/ogm-aardvark/#description
 Field Name,dct_description_sm
 Field Type,Array of strings
-Obligation,Mandatory - used in Google indexing
+Obligation,Mandatory - used in search engine indexing
 Multivalued,True
 Purpose,To provide the user with a summary of the resource.
 Entry Guidelines,"At a minimum, this is a reiteration of the title in sentence format. Other relevant information, such as data creation methods, data sources, and special licenses, may also be included."

--- a/docs/ogm-aardvark/description.csv
+++ b/docs/ogm-aardvark/description.csv
@@ -2,7 +2,7 @@ Label,Description
 URI,https://opengeometadata.org/ogm-aardvark/#description
 Field Name,dct_description_sm
 Field Type,Array of strings
-Obligation,Suggested
+Obligation,Mandatory - used in Google indexing
 Multivalued,True
 Purpose,To provide the user with a summary of the resource.
 Entry Guidelines,"At a minimum, this is a reiteration of the title in sentence format. Other relevant information, such as data creation methods, data sources, and special licenses, may also be included."
@@ -10,4 +10,4 @@ Commentary,"This field is the second-most prominent value (after [Title](../ogm-
 Controlled Vocabulary,No
 Example Value,"""This polygon shapefile represents boundaries of election districts in New York City. It was harvested from the NYC Open Data Portal."""
 Element Set,DCMI
-Group,"[Descriptive](../ogm-aardvark/#descriptive)"
+Group,Descriptive

--- a/docs/ogm-aardvark/display-note.csv
+++ b/docs/ogm-aardvark/display-note.csv
@@ -10,4 +10,4 @@ Commentary,"Starting in GeoBlacklight version 4.1, text in this field is promine
 Controlled Vocabulary,No
 Example Value,"[""Danger: This text will be displayed in a red box"",""Info: This text will be displayed in a blue box"",""Tip: This text will be displayed in a green box"",""Warning: This text will be displayed in a yellow box"",""This is text without a tag and it will be assigned the default 'note' style""]"
 Element Set,GBL
-Group,"[Descriptive](../ogm-aardvark/#descriptive)"
+Group,Descriptive

--- a/docs/ogm-aardvark/file-size.csv
+++ b/docs/ogm-aardvark/file-size.csv
@@ -10,4 +10,4 @@ Commentary,"This field is intended to give users a sense of how large the data o
 Controlled Vocabulary,No
 Example Value,"""25.96 MB"""
 Element Set,GBL
-Group,"[Object](../ogm-aardvark/#object)"
+Group,Object

--- a/docs/ogm-aardvark/format.csv
+++ b/docs/ogm-aardvark/format.csv
@@ -2,7 +2,7 @@ Label,Format
 URI,https://opengeometadata.org/ogm-aardvark/#format
 Field Name,dct_format_s
 Field Type,String
-Obligation,Conditionally required
+Obligation,Mandatory - used to generate citations; critical for GeoBlacklight functioning
 Multivalued,False
 Purpose,To display to the user the name of the file type as a text string in the download button.
 Entry Guidelines,"Enter a string describing the file format, preferably from the list of [Format Values](../ogm-aardvark/#format-values)."
@@ -10,4 +10,4 @@ Commentary,"This field is required if the download URL (`http://schema.org/downl
 Controlled Vocabulary,Yes - not strict
 Example Value,"""Shapefile"""
 Element Set,DCMI
-Group,"[Object](../ogm-aardvark/#object)"
+Group,Object

--- a/docs/ogm-aardvark/geometry.csv
+++ b/docs/ogm-aardvark/geometry.csv
@@ -2,7 +2,7 @@ Label,Geometry
 URI,https://opengeometadata.org/ogm-aardvark/#geometry
 Field Name,locn_geometry
 Field Type,String
-Obligation,Suggested
+Obligation,Mandatory - powers the map search and extent indicators in GeoBlacklight software 
 Multivalued,False
 Purpose,To display the extent of the resource and to power the map search.
 Entry Guidelines,"This may be a bounding box or more complex geometry. For a bounding box, it should use the ENVELOPE(W,E,N,S) syntax. For a more complex geometry, it should use the WKT (""well-known text"") POLYGON or MULTIPOLYGON syntax. Note that WKT polygon vertices should be defined in counter-clockwise order."
@@ -10,4 +10,4 @@ Commentary,"Since this field is not repeatable, multiple polygons should be repr
 Controlled Vocabulary,No
 Example Value,"Simple bounding box: ""ENVELOPE(-111.1, -104.0, 45.0, 40.9)""  |  Bermuda Triangle: ""POLYGON((-80 25, -65 18, -64 33, -80 25))""  |  Split bounding box for Alaska: ""MULTIPOLYGON (((-179.3 51.1, -129.9 51.1, -129.9 71.5, -179.3 71.5, -179.3 51.1)),((172.3 51.2, 179.9 51.2, 179.9 53.1, 172.3 53.1, 172.3 51.2)))"""
 Element Set,LOCN
-Group,"[Spatial](../ogm-aardvark/#spatial)"
+Group,[Spatial](../spatial-fields)

--- a/docs/ogm-aardvark/geometry.csv
+++ b/docs/ogm-aardvark/geometry.csv
@@ -2,7 +2,7 @@ Label,Geometry
 URI,https://opengeometadata.org/ogm-aardvark/#geometry
 Field Name,locn_geometry
 Field Type,String
-Obligation,Mandatory - powers the map search and extent indicators in GeoBlacklight software 
+Obligation,Mandatory - powers the map search and extent indicators in GeoBlacklight 
 Multivalued,False
 Purpose,To display the extent of the resource and to power the map search.
 Entry Guidelines,"This may be a bounding box or more complex geometry. For a bounding box, it should use the ENVELOPE(W,E,N,S) syntax. For a more complex geometry, it should use the WKT (""well-known text"") POLYGON or MULTIPOLYGON syntax. Note that WKT polygon vertices should be defined in counter-clockwise order."

--- a/docs/ogm-aardvark/georeferenced.csv
+++ b/docs/ogm-aardvark/georeferenced.csv
@@ -10,4 +10,4 @@ Commentary,This field can be a shortcut for users to find georeferenced maps. Ad
 Controlled Vocabulary,Yes - strict
 Example Value,"false or ""false"""
 Element Set,GBL
-Group,"[Spatial](../ogm-aardvark/#spatial)"
+Group,[Spatial](../spatial-fields)

--- a/docs/ogm-aardvark/id.csv
+++ b/docs/ogm-aardvark/id.csv
@@ -2,7 +2,7 @@ Label,ID
 URI,https://opengeometadata.org/ogm-aardvark/#id
 Field Name,id
 Field Type,String
-Obligation,Required
+Obligation,Mandatory - serves as the unique identifier; critical from GeoBlacklight functioning
 Multivalued,False
 Purpose,To provide a unique text string for the item that will act as the primary key in Solr and to create a unique landing page for the item.
 Entry Guidelines,"Enter a string that only contains alpha-numeric characters (A-Z, a-z, 0-9), hyphens, underscores, and colons. This ID must be unique within your instance's GeoBlacklight index."
@@ -10,4 +10,4 @@ Commentary,"The value of this field will appear in Geoblacklight's URL for the i
 Controlled Vocabulary,No
 Example Value,"""princeton-rv042w38t"""
 Element Set,GBL
-Group,"[Identifiers](../ogm-aardvark/#identifiers)"
+Group,Identifiers

--- a/docs/ogm-aardvark/id.csv
+++ b/docs/ogm-aardvark/id.csv
@@ -2,7 +2,7 @@ Label,ID
 URI,https://opengeometadata.org/ogm-aardvark/#id
 Field Name,id
 Field Type,String
-Obligation,Mandatory - serves as the unique identifier; critical from GeoBlacklight functioning
+Obligation,Mandatory - serves as the unique identifier; critical for GeoBlacklight functioning
 Multivalued,False
 Purpose,To provide a unique text string for the item that will act as the primary key in Solr and to create a unique landing page for the item.
 Entry Guidelines,"Enter a string that only contains alpha-numeric characters (A-Z, a-z, 0-9), hyphens, underscores, and colons. This ID must be unique within your instance's GeoBlacklight index."

--- a/docs/ogm-aardvark/identifier.csv
+++ b/docs/ogm-aardvark/identifier.csv
@@ -2,7 +2,7 @@ Label,Identifier
 URI,https://opengeometadata.org/ogm-aardvark/#identifier
 Field Name,dct_identifier_sm
 Field Type,Array of strings
-Obligation,Suggested
+Obligation,Optional
 Multivalued,True
 Purpose,To provide a general purpose field for identifiers.
 Entry Guidelines,"Enter a DOI, catalog number, and/or other system number."
@@ -10,4 +10,4 @@ Commentary,"This is a general purpose field that can contain one or more string 
 Controlled Vocabulary,No
 Example Value,"[""5864 .L7 E635 1998 .G7""]"
 Element Set,DCMI
-Group,"[Identifiers](../ogm-aardvark/#identifiers)"
+Group,Identifiers

--- a/docs/ogm-aardvark/index-year.csv
+++ b/docs/ogm-aardvark/index-year.csv
@@ -2,7 +2,7 @@ Label,Index Year
 URI,https://opengeometadata.org/ogm-aardvark/#index-year
 Field Name,gbl_indexYear_im
 Field Type,Array of integers
-Obligation,Suggested
+Obligation,Suggested - powers a search facet in GeoBlacklight
 Multivalued,True
 Purpose,"To power the ""Year"" facet and time slider widgets that rely on integers for dates."
 Entry Guidelines,Enter one or more 4-digit integers.
@@ -10,4 +10,4 @@ Commentary,"Ideally this field should describe the date(s) depicted in a resourc
 Controlled Vocabulary,No
 Example Value,"[1980,1981,1982]"
 Element Set,GBL
-Group,"[Temporal](../ogm-aardvark/#temporal)"
+Group,[Temporal](../temporal-fields)

--- a/docs/ogm-aardvark/is-part-of.csv
+++ b/docs/ogm-aardvark/is-part-of.csv
@@ -10,4 +10,4 @@ Commentary,"This is one of several fields that describe how records relate to ea
 Controlled Vocabulary,No
 Example Value,"[""77f-0001""]"
 Element Set,DCMI
-Group,"[Relations](../ogm-aardvark/#relations)"
+Group,[Relations](../relations-fields)

--- a/docs/ogm-aardvark/is-replaced-by.csv
+++ b/docs/ogm-aardvark/is-replaced-by.csv
@@ -10,4 +10,4 @@ Commentary,"This field can be used with [Replaces](../ogm-aardvark/#replaces) to
 Controlled Vocabulary,No
 Example Value,"[""cugir-007933""]"
 Element Set,DCMI
-Group,"[Relations](../ogm-aardvark/#relations)"
+Group,[Relations](../relations-fields)

--- a/docs/ogm-aardvark/is-version-of.csv
+++ b/docs/ogm-aardvark/is-version-of.csv
@@ -10,4 +10,4 @@ Commentary,"If entering the ID of a parent record, see [Member Of](../ogm-aardva
 Controlled Vocabulary,No
 Example Value,"[""xyz-1234""]"
 Element Set,DCMI
-Group,"[Relations](../ogm-aardvark/#relations)"
+Group,[Relations](../relations-fields)

--- a/docs/ogm-aardvark/keyword.csv
+++ b/docs/ogm-aardvark/keyword.csv
@@ -10,4 +10,4 @@ Commentary,This field may be used for administrative purposes or to facilitate t
 Controlled Vocabulary,No
 Example Value,"[""covid19"", ""vaccination rate""]"
 Element Set,DCAT
-Group,"[Categories](../ogm-aardvark/#categories)"
+Group,Categories

--- a/docs/ogm-aardvark/language.csv
+++ b/docs/ogm-aardvark/language.csv
@@ -10,4 +10,4 @@ Commentary,"This field is intended to indicate the language of the dataset, map,
 Controlled Vocabulary,"Yes - not strict. Ideally, choose from the ISO 639-3 language codes in the list of [Language Values](../ogm-aardvark/#language-values) below."
 Example Value,"[""eng""]"
 Element Set,DCMI
-Group,"[Descriptive](../ogm-aardvark/#descriptive)"
+Group,Descriptive

--- a/docs/ogm-aardvark/license.csv
+++ b/docs/ogm-aardvark/license.csv
@@ -10,4 +10,4 @@ Commentary,"This field is only for URIs of known licenses. Do not enter a rights
 Controlled Vocabulary,No
 Example Value,"[""https://creativecommons.org/licenses/by/4.0/""]"
 Element Set,DCMI
-Group,"[Rights](../ogm-aardvark/#rights)"
+Group,Rights

--- a/docs/ogm-aardvark/member-of.csv
+++ b/docs/ogm-aardvark/member-of.csv
@@ -10,4 +10,4 @@ Commentary,"This is one of several fields that describe how records relate to ea
 Controlled Vocabulary,No
 Example Value,"[""xyz-12394""]"
 Element Set,PCDM
-Group,"[Relations](../ogm-aardvark/#relations)"
+Group,[Relations](../relations-fields)

--- a/docs/ogm-aardvark/metadata-version.csv
+++ b/docs/ogm-aardvark/metadata-version.csv
@@ -2,7 +2,7 @@ Label,Metadata Version
 URI,https://opengeometadata.org/ogm-aardvark/#metadata-version
 Field Name,gbl_mdVersion_s
 Field Type,String
-Obligation,Required
+Obligation,Mandatory - harvesters rely on this field to parse metadata
 Multivalued,False
 Purpose,To clarify which GeoBlacklight metadata schema is being used.
 Entry Guidelines,Enter a string: "GBL 1.0" or "Aardvark".
@@ -10,4 +10,4 @@ Commentary,"There have been two metadata schema versions for GeoBlacklight appli
 Controlled Vocabulary,Yes - strict
 Example Value,"""Aardvark"""
 Element Set,GBL
-Group,"[Admin](../ogm-aardvark/#admin)"
+Group,Admin

--- a/docs/ogm-aardvark/modified.csv
+++ b/docs/ogm-aardvark/modified.csv
@@ -2,7 +2,7 @@ Label,Modified
 URI,https://opengeometadata.org/ogm-aardvark/#modified
 Field Name,gbl_mdModified_dt
 Field Type,String
-Obligation,Required
+Obligation,Optional
 Multivalued,False
 Purpose,To inform administrators of when the metadata was last touched.
 Entry Guidelines,"Use the ""W3C Date and Time Format"" (YYYY-MM-DDThh:<zero-width space>mm:ssZ)"
@@ -10,4 +10,4 @@ Commentary,This value should indicate when the metadata (not the resource itself
 Controlled Vocabulary,No
 Example Value,"""2015-01-01T12:00:00Z"""
 Element Set,GBL
-Group,"[Admin](../ogm-aardvark/#admin)"
+Group,Admin

--- a/docs/ogm-aardvark/ogm-aardvark.csv
+++ b/docs/ogm-aardvark/ogm-aardvark.csv
@@ -1,0 +1,43 @@
+Label,Field Name,Category,Mandatory,Suggested,Controlled Values
+[Access Rights](#access-rights),dct_accessRights_s,Rights,X, , 
+[Alternative Title](#alternative-title),dct_alternative_sm,Descriptive, , , 
+[Bounding Box](#bounding-box),dcat_bbox,[Spatial](../spatial-fields),X, , 
+[Centroid](#centroid),dcat_centroid,[Spatial](../spatial-fields), , , 
+[Creator](#creator),dct_creator_sm,Credits, ,X, 
+[Date Issued](#date-issued),dct_issued_s,[Temporal](../temporal-fields), ,X, 
+[Date Range](#date-range),gbl_dateRange_drsim,[Temporal](../temporal-fields), , , 
+[Description](#description),dct_description_sm,Descriptive,X, , 
+[Display Note](#display-note),gbl_displayNote_sm,Descriptive, , , 
+[File Size](#file-size),gbl_fileSize_s,Object, , , 
+[Format](#format),dct_format_s,Object,X, ,X
+[Geometry](#geometry),locn_geometry,[Spatial](../spatial-fields),X, , 
+[Georeferenced](#georeferenced),gbl_georeferenced_b,[Spatial](../spatial-fields), , , 
+[ID](#id),id,Identifiers,X, , 
+[Identifier](#identifier),dct_identifier_sm,Identifiers, , , 
+[Index Year](#index-year),gbl_indexYear_im,[Temporal](../temporal-fields), ,X, 
+[Is Part Of](#is-part-of),dct_isPartOf_sm,[Relations](../relations-fields), , , 
+[Is Replaced By](#is-replaced-by),dct_isReplacedBy_sm,[Relations](../relations-fields), , , 
+[Is Version Of](#is-version-of),dct_isVersionOf_sm,[Relations](../relations-fields), , , 
+[Keyword](#keyword),dcat_keyword_sm,Categories, , , 
+[Language](#language),dct_language_sm,Descriptive, , ,X
+[License](#license),dct_license_sm,Rights, , , 
+[Member Of](#member-of),pcdm_memberOf_sm,[Relations](../relations-fields), , , 
+[Metadata Version](#metadata-version),gbl_mdVersion_s,Admin,X, ,X
+[Modified](#modified),gbl_mdModified_dt,Admin, , , 
+[Provider](#provider),schema_provider_s,Credits,X, , 
+[Publisher](#publisher),dct_publisher_sm,Credits, ,X, 
+[References](#references),dct_references_s,Links,X, , 
+[Relation](#relation),dct_relation_sm,[Relations](../relations-fields), , , 
+[Replaces](#replaces),dct_replaces_sm,[Relations](../relations-fields), , , 
+[Resource Class](#resource-class),gbl_resourceClass_sm,Categories,X, ,X
+[Resource Type](#resource-type),gbl_resourceType_sm,Categories, ,X,X
+[Rights Holder](#rights-holder),dct_rightsHolder_sm,Rights, , , 
+[Rights](#rights),dct_rights_sm,Rights, , , 
+[Source](#source),dct_source_sm,[Relations](../relations-fields), , , 
+[Spatial Coverage](#spatial-coverage),dct_spatial_sm,[Spatial](../spatial-fields), ,X, 
+[Subject](#subject),dct_subject_sm,Categories, , , 
+[Suppressed](#suppressed),gbl_suppressed_b,Admin, , , 
+[Temporal Coverage](#temporal-coverage),dct_temporal_sm,[Temporal](../temporal-fields), , , 
+[Theme](#theme),dcat_theme_sm,Categories, ,X,X
+[Title](#title),dct_title_s,Descriptive,X, , 
+[WxS Identifier](#wxs-identifier),gbl_wxsIdentifier_s,Links, , , 

--- a/docs/ogm-aardvark/provider.csv
+++ b/docs/ogm-aardvark/provider.csv
@@ -2,7 +2,7 @@ Label,Provider
 URI,https://opengeometadata.org/ogm-aardvark/#provider
 Field Name,schema_provider_s
 Field Type,String
-Obligation,Suggested
+Obligation,Mandatory - describes provenance; used to determine if a resource is accessible to a user
 Multivalued,False
 Purpose,To clarify which organization holds the resource or acts as the custodian for the metadata record and to help users understand which resources they can access.
 Entry Guidelines,"This field can be any string value. However, if the value corresponds to the name of an SVG icon in GeoBlacklight, the icon will display next to the title. See the GeoBlacklight documentation on [adding SVG Icons](https://geoblacklight.org/docs/adding_svg_icons/) for more details."
@@ -10,4 +10,4 @@ Commentary,This field was named **Provenance** in the GBL 1.0 metadata schema.
 Controlled Vocabulary,Yes - not strict
 Example Value,"""University of Minnesota"""
 Element Set,schema.org
-Group,"[Credits](../ogm-aardvark/#credits)"
+Group,Credits

--- a/docs/ogm-aardvark/publisher.csv
+++ b/docs/ogm-aardvark/publisher.csv
@@ -2,7 +2,7 @@ Label,Publisher
 URI,https://opengeometadata.org/ogm-aardvark/#publisher
 Field Name,dct_publisher_sm
 Field Type,Array of strings
-Obligation,Suggested
+Obligation,Suggested - helpful for generating citations
 Multivalued,True
 Purpose,To credit the entity that made a resource available for the first time.
 Entry Guidelines,The suggested controlled vocabulary is the [Library of Congress Name Authority File](https://id.loc.gov/authorities/names.html).
@@ -10,4 +10,4 @@ Commentary,"The distinction between Publisher and [Creator](../ogm-aardvark/#cre
 Controlled Vocabulary,No
 Example Value,"[""ML InfoMap (Firm)""]"
 Element Set,DCMI
-Group,"[Credits](../ogm-aardvark/#credits)"
+Group,Credits

--- a/docs/ogm-aardvark/references.csv
+++ b/docs/ogm-aardvark/references.csv
@@ -2,7 +2,7 @@ Label,References
 URI,https://opengeometadata.org/ogm-aardvark/#references
 Field Name,dct_references_s
 Field Type,String (serialized JSON)
-Obligation,Mandatory - used for download links and to direct users to more information
+Obligation,Mandatory - used to provide download links and direct users to more information
 Multivalued,False
 Purpose,To provide external URLs for accessing or describing the resource.
 Entry Guidelines,"This field defines external services and references using the CatInterOp approach. The field value is a serialized JSON array of key/value pairs, with keys representing namespace URI's and values the URL. See [Configure References Links](../configure-references-links/) for detailed information about configuring this field."

--- a/docs/ogm-aardvark/references.csv
+++ b/docs/ogm-aardvark/references.csv
@@ -2,7 +2,7 @@ Label,References
 URI,https://opengeometadata.org/ogm-aardvark/#references
 Field Name,dct_references_s
 Field Type,String (serialized JSON)
-Obligation,Suggested
+Obligation,Mandatory - used for download links and to direct users to more information
 Multivalued,False
 Purpose,To provide external URLs for accessing or describing the resource.
 Entry Guidelines,"This field defines external services and references using the CatInterOp approach. The field value is a serialized JSON array of key/value pairs, with keys representing namespace URI's and values the URL. See [Configure References Links](../configure-references-links/) for detailed information about configuring this field."
@@ -10,4 +10,4 @@ Commentary,"All of the external links for the resource are listed as a serialize
 Controlled Vocabulary,"The ""key"" part of the key/value pairs are predefined in [Reference URIs](../reference-uris/)."
 Example Value,"""{\""http://schema.org/url\"":\""http://purl.stanford.edu/bm662dm5913\""}"""
 Element Set,DCMI
-Group,"[Links](../ogm-aardvark/#links)"
+Group,Links

--- a/docs/ogm-aardvark/relation.csv
+++ b/docs/ogm-aardvark/relation.csv
@@ -10,4 +10,4 @@ Commentary,"This is one of several fields that describe how records relate to ea
 Controlled Vocabulary,No
 Example Value,"[""aoeu-987643""]"
 Element Set,DCMI
-Group,"[Relations](../ogm-aardvark/#relations)"
+Group,[Relations](../relations-fields)

--- a/docs/ogm-aardvark/replaces.csv
+++ b/docs/ogm-aardvark/replaces.csv
@@ -10,4 +10,4 @@ Commentary,"This field can be used on its own to point to an older deprecated da
 Controlled Vocabulary,No
 Example Value,"[""qrst-71717""]"
 Element Set,DCMI
-Group,"[Relations](../ogm-aardvark/#relations)"
+Group,[Relations](../relations-fields)

--- a/docs/ogm-aardvark/resource-class.csv
+++ b/docs/ogm-aardvark/resource-class.csv
@@ -2,7 +2,7 @@ Label,Resource Class
 URI,https://opengeometadata.org/ogm-aardvark/#resource-class
 Field Name,gbl_resourceClass_sm
 Field Type,Array of strings
-Obligation,Required
+Obligation,Mandatory - helpful for starting a search
 Multivalued,True
 Purpose,To provide a top level set of categories for classifying the item.
 Entry Guidelines,"Choose one or more terms from the list of [Resource Class Values](../ogm-aardvark/#resource-class-values) below."
@@ -10,4 +10,4 @@ Commentary,This field is intended to help users sort between significantly diffe
 Controlled Vocabulary,Yes - strict
 Example Value,"[""Datasets""]"
 Element Set,GBL
-Group,"[Categories](../ogm-aardvark/#categories)"
+Group,Categories

--- a/docs/ogm-aardvark/resource-type.csv
+++ b/docs/ogm-aardvark/resource-type.csv
@@ -2,7 +2,7 @@ Label,Resource Type
 URI,https://opengeometadata.org/ogm-aardvark/#resource-type
 Field Name,gbl_resourceType_sm
 Field Type,Array of strings
-Obligation,Suggested
+Obligation,Suggested - helpful for narrowing down a search
 Multivalued,True
 Purpose,To provide a secondary level of categories for classifying the spatial type or structure of a dataset.
 Entry Guidelines,Choose one or more terms from the lists of [Library of Congress](../ogm-aardvark/#resource-type-values-loc) or [OpenGeoMetadata](https://opengeometadata.org/ogm-aardvark/#resource-type-values-ogm) Resource Type Values below. Other terms are allowed.
@@ -10,4 +10,4 @@ Commentary,This field combines an established list of terms for scanned maps (Ca
 Controlled Vocabulary,Yes - not strict
 Example Value,"[""Point data""]"
 Element Set,GBL
-Group,"[Categories](../ogm-aardvark/#categories)"
+Group,Categories

--- a/docs/ogm-aardvark/rights-holder.csv
+++ b/docs/ogm-aardvark/rights-holder.csv
@@ -10,4 +10,4 @@ Commentary,"This field can be used for instances in which an an organization own
 Controlled Vocabulary,No
 Example Value,"""Johns Hopkins University Libraries"""
 Element Set,DCMI
-Group,"[Rights](../ogm-aardvark/#rights)"
+Group,Rights

--- a/docs/ogm-aardvark/rights.csv
+++ b/docs/ogm-aardvark/rights.csv
@@ -2,7 +2,7 @@ Label,Rights
 URI,https://opengeometadata.org/ogm-aardvark/#rights_1
 Field Name,dct_rights_sm
 Field Type,Array of strings
-Obligation,Suggested
+Obligation,Optional
 Multivalued,True
 Purpose,"To provide a free text field for rights information, such as usage, access, or copyright."
 Entry Guidelines,"Enter free text of generic, catch-all access and usage rights."
@@ -10,4 +10,4 @@ Commentary,"This field is intended to be flexible to accommodate different types
 Controlled Vocabulary,No
 Example Value,"""All data is copyrighted by China Data Center and/or its suppliers. Derived works that include the source data must be merged with other value-added data in such a way that the derived work cannot be converted back to the original source data format. This data is licensed by UC Berkeley for research, educational, and other non-commercial use by authorized users, which include persons affiliated with UC Berkeley and walk-in users who must access the data in person at the library. [https://rightsstatements.org/page/InC/1.0/?language=en](https://rightsstatements.org/page/InC/1.0/?language=en)."""
 Element Set,DCMI
-Group,"[Rights](../ogm-aardvark/#rights)"
+Group,Rights

--- a/docs/ogm-aardvark/source.csv
+++ b/docs/ogm-aardvark/source.csv
@@ -10,4 +10,4 @@ Commentary,"This is one of several fields that describe how records relate to ea
 Controlled Vocabulary,No
 Example Value,"[""abcd-988763""]"
 Element Set,DCMI
-Group,"[Relations](../ogm-aardvark/#relations)"
+Group,[Relations](../relations-fields)

--- a/docs/ogm-aardvark/spatial-coverage.csv
+++ b/docs/ogm-aardvark/spatial-coverage.csv
@@ -2,7 +2,7 @@ Label,Spatial Coverage
 URI,https://opengeometadata.org/ogm-aardvark/#spatial-coverage
 Field Name,dct_spatial_sm
 Field Type,Array of strings
-Obligation,Suggested
+Obligation,Suggested - helpful for searching by place name
 Multivalued,True
 Purpose,To provide the user with a list of searchable and selectable place names.
 Entry Guidelines,"Place name text strings should be specified out to the nation level. It is typical for the place name to represent the largest extent the data layer represents. Our recommended thesaurus is [GeoNames](https://www.geonames.org/)."
@@ -10,4 +10,4 @@ Commentary,"It is recommended to have at least one place name for each layer tha
 Controlled Vocabulary,No
 Example Value,"[""Philadelphia, Pennsylvania, United States""]"
 Element Set,DCMI
-Group,"[Spatial](../ogm-aardvark/#spatial)"
+Group,[Spatial](../spatial-fields)

--- a/docs/ogm-aardvark/subject.csv
+++ b/docs/ogm-aardvark/subject.csv
@@ -10,4 +10,4 @@ Commentary,"Institutions may rely on existing vocabularies specific to a field o
 Controlled Vocabulary,No
 Example Value,"[""Elections"", ""Voting""]"
 Element Set,DCMI
-Group,"[Categories](../ogm-aardvark/#categories)"
+Group,Categories

--- a/docs/ogm-aardvark/suppressed.csv
+++ b/docs/ogm-aardvark/suppressed.csv
@@ -10,4 +10,4 @@ Commentary,"This field is useful for multipart items with identical metadata, su
 Controlled Vocabulary,Yes - strict
 Example Value,"true or ""true"""
 Element Set,GBL
-Group,"[Admin](../ogm-aardvark/#admin)"
+Group,Admin

--- a/docs/ogm-aardvark/temporal-coverage.csv
+++ b/docs/ogm-aardvark/temporal-coverage.csv
@@ -2,7 +2,7 @@ Label,Temporal Coverage
 URI,https://opengeometadata.org/ogm-aardvark/#temporal-coverage
 Field Name,dct_temporal_sm
 Field Type,Array of strings
-Obligation,Suggested
+Obligation,Optional
 Multivalued,True
 Purpose,"To provide the user with a free text description of the time period or ranges of what is depicted in the resource."
 Entry Guidelines,"This is a text string and can indicate uncertainty."
@@ -10,4 +10,4 @@ Commentary,"Since this field is multi-valued, multiple strings can be used to in
 Controlled Vocabulary,No
 Example Value,"[""1980-1995"", ""Late 20th century""]"
 Element Set,DCMI
-Group,"[Temporal](../ogm-aardvark/#temporal)"
+Group,[Temporal](../temporal-fields)

--- a/docs/ogm-aardvark/theme.csv
+++ b/docs/ogm-aardvark/theme.csv
@@ -2,7 +2,7 @@ Label,Theme
 URI,https://opengeometadata.org/ogm-aardvark/#theme
 Field Name,dcat_theme_sm
 Field Type,Array of strings
-Obligation,Optional
+Obligation,Suggested - helpful for starting a search
 Multivalued,True
 Purpose,To provide a dedicated field that is restricted to terms based on ISO Topic Categories.
 Entry Guidelines,"Insert one or more of the values from the list of [Theme Values](../ogm-aardvark/#theme-values) below."
@@ -10,4 +10,4 @@ Commentary,"Although ISO Topic categories are well established and widely used, 
 Controlled Vocabulary,Yes - strict
 Example Value,"[""Boundaries"", ""Land Cover""]"
 Element Set,DCAT
-Group,"[Categories](../ogm-aardvark/#categories)"
+Group,Categories

--- a/docs/ogm-aardvark/title.csv
+++ b/docs/ogm-aardvark/title.csv
@@ -2,7 +2,7 @@ Label,Title
 URI,https://opengeometadata.org/ogm-aardvark/#title
 Field Name,dct_title_s
 Field Type,String
-Obligation,Required
+Obligation,Mandatory - used to generate citations; GeoBlacklight will use a default placeholder if no title is provided
 Multivalued,False
 Purpose,To provide the user with the name of the resource.
 Entry Guidelines,Titles should include place names and dates when available.
@@ -10,4 +10,4 @@ Commentary,"The title is the most prominent metadata field that users see when b
 Controlled Vocabulary,No
 Example Value,"""Address Points: Ann Arbor, Michigan, 2010"""
 Element Set,DCMI
-Group,"[Descriptive](../ogm-aardvark/#descriptive)"
+Group,Descriptive

--- a/docs/ogm-aardvark/wxs-identifier.csv
+++ b/docs/ogm-aardvark/wxs-identifier.csv
@@ -2,7 +2,7 @@ Label,WxS Identifier
 URI,https://opengeometadata.org/ogm-aardvark/#wxs-identifier
 Field Name,gbl_wxsIdentifier_s
 Field Type,String
-Obligation,Conditionally required
+Obligation,Optional - only required if using GeoServer with a GeoBlacklight instance
 Multivalued,False
 Purpose,"To identify the layer or store for a WFS, WMS, or WCS web service so the application can construct the full web service link."
 Entry Guidelines,"Only the layer name is added here. The base service endpoint URLs (e.g. ""https://maps-public.geo.nyu.edu/geoserver/sdr/wms"") are added to the [References](../ogm-aardvark/#references) field."
@@ -10,4 +10,4 @@ Commentary,This value is only used when a WxS service is listed in the [Referenc
 Controlled Vocabulary,No
 Example Value,"""druid:vr593vj7147"""
 Element Set,GBL
-Group,"[Links](../ogm-aardvark/#links)"
+Group,Links


### PR DESCRIPTION
Refreshes the [OGM Aardvark page](https://opengeometadata.org/ogm-aardvark/):
* clarifies that the GBL documentation should be consulted for fields required for software functionality
* reformats the list of fields as a table
* implements new field obligations from [https://github.com/OpenGeoMetadata/metadata-issues/issues/24]
* adds explanatory text about why we chose 'mandatory' or 'suggested' for each field

Closes https://github.com/OpenGeoMetadata/metadata-issues/issues/62 

### Current website
<img width="792" height="789" alt="Screenshot 2025-07-25 at 3 06 38 PM" src="https://github.com/user-attachments/assets/7e95db79-1a6c-4aa5-8391-61adfc45f461" />

### Proposed change
<img width="771" height="788" alt="Screenshot 2025-07-25 at 3 06 57 PM" src="https://github.com/user-attachments/assets/73b3790f-ccce-4f58-8516-829bf814781d" />
