### PR TITLE
Add locn_geometry to required fields in Aardvark schema JSON

### DIFF
--- a/docs/schema/geoblacklight-schema-aardvark.json
+++ b/docs/schema/geoblacklight-schema-aardvark.json
@@ -193,5 +193,5 @@
     "gbl_suppressed_b": { "type": "boolean" },
     "gbl_georeferenced_b": { "type": "boolean" }
   },
-  "required": ["id", "dct_title_s", "gbl_resourceClass_sm", "dct_accessRights_s", "gbl_mdVersion_s"]
+  "required": ["id", "dct_title_s", "gbl_resourceClass_sm", "dct_accessRights_s", "gbl_mdVersion_s", "locn_geometry"]
 }


### PR DESCRIPTION
According to the documentation (and Solr!) `locn_geometry` should be a required field.